### PR TITLE
Add Pollard runtime options and parser support

### DIFF
--- a/CmdParse/CmdParse.cpp
+++ b/CmdParse/CmdParse.cpp
@@ -34,42 +34,54 @@ bool CmdParse::get(const std::string opt, ArgType &t)
 
 void CmdParse::parse(int argc, char **argv)
 {
-	for(int i = 1; i < argc; i++) {
-		std::string arg(argv[i]);
+        for(int i = 1; i < argc; i++) {
+                std::string arg(argv[i]);
 
-		ArgType t;
-		if(get(arg, t)) {
-			// It is an option
+                std::string opt = arg;
+                std::string optValue;
 
-			OptArg a;
+                // Allow options in the form --option=value
+                size_t pos = arg.find('=');
+                if(pos != std::string::npos) {
+                        opt = arg.substr(0, pos);
+                        optValue = arg.substr(pos + 1);
+                }
 
-			if(t.hasArg) {
-				// It requires an argument
+                ArgType t;
+                if(get(opt, t)) {
+                        // It is an option
 
-				if(i == argc - 1) {
-					throw std::string("'" + arg + "' requires an argument");
-				}
+                        OptArg a;
 
-				std::string optArg(argv[i + 1]);
-				i++;
-				a.option = arg;
-				a.arg = optArg;
+                        if(t.hasArg) {
+                                // It requires an argument
 
-			} else {
-				// It does not require an argument
+                                if(pos == std::string::npos) {
+                                        if(i == argc - 1) {
+                                                throw std::string("'" + opt + "' requires an argument");
+                                        }
 
-				a.option = arg;
-				a.arg = "";
-			}
+                                        optValue = std::string(argv[++i]);
+                                }
 
-			_optArgs.push_back(a);
-			
-		} else {
-			// It is an operand
+                                a.option = opt;
+                                a.arg = optValue;
 
-			_operands.push_back(arg);
-		}
-	}
+                        } else {
+                                // It does not require an argument
+
+                                a.option = opt;
+                                a.arg = "";
+                        }
+
+                        _optArgs.push_back(a);
+
+                } else {
+                        // It is an operand
+
+                        _operands.push_back(arg);
+                }
+        }
 }
 
 std::vector<OptArg> CmdParse::getArgs()

--- a/CmdParse/CmdParse.h
+++ b/CmdParse/CmdParse.h
@@ -50,7 +50,7 @@ public:
 
 	std::vector<OptArg> getArgs();
 
-	std::vector<std::string> getOperands();
+        std::vector<std::string> getOperands();
 };
 
 #endif


### PR DESCRIPTION
## Summary
- add CLI flags for Pollard Rho parameters (`--pollard`, `--offsets`, `--window-size`, `--tames`, `--wilds`)
- extend CmdParse to support `--option=value` syntax
- wire parsed Pollard options through run configuration with stub runtime selection

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_688ea2d4a2c8832e9fd12e0f9769a04a