### PR TITLE
Include Pollard CRT sources in build

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -1,4 +1,4 @@
-CPPSRC:=$(wildcard *.cpp)
+CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
 
 all:
 ifeq ($(BUILD_CUDA), 1)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 CUR_DIR=$(shell pwd)
-DIRS=util AddressUtil CmdParse CryptoUtil KeyFinderLib CLKeySearchDevice CudaKeySearchDevice cudaMath clUtil cudaUtil secp256k1lib Logger embedcl
+DIRS=util AddressUtil CmdParse CryptoUtil KeyFinderLib KeyFinder CLKeySearchDevice CudaKeySearchDevice cudaMath clMath clUtil cudaUtil secp256k1lib Logger embedcl
 
 INCLUDE = $(foreach d, $(DIRS), -I$(CUR_DIR)/$d)
 


### PR DESCRIPTION
## Summary
- Expose Pollard engine and CRT utility headers by adding `KeyFinder` and `clMath` to global include directories.
- Explicitly compile PollardEngine as part of KeyFinder sources for both CUDA and OpenCL builds.

## Testing
- `make BUILD_CUDA=1` *(fails: fatal error: cuda.h: No such file or directory)*
- `make BUILD_OPENCL=1` *(fails: fatal error: CL/cl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688ed813bcc8832eb77cba8076c5915c