### PR TITLE
Add deterministic Pollard tests

### DIFF
--- a/KeyFinder/PollardEngine.cpp
+++ b/KeyFinder/PollardEngine.cpp
@@ -95,9 +95,13 @@ void PollardEngine::enumerateCandidate(const uint256 &priv, const ecpoint &pub) 
 }
 
 void PollardEngine::runTameWalk(const uint256 &start, uint64_t steps) {
+    runTameWalk(start, steps, std::random_device{}());
+}
+
+void PollardEngine::runTameWalk(const uint256 &start, uint64_t steps, uint64_t seed) {
     // Random-step walk beginning at ``start``.  At each distinguished point
     // windows from the current scalar are recorded and fed to the CRT solver.
-    std::mt19937_64 rng(std::random_device{}());
+    std::mt19937_64 rng(seed);
 
     uint64_t maxStep;
     if(_windowBits >= 64) {
@@ -139,10 +143,14 @@ void PollardEngine::runTameWalk(const uint256 &start, uint64_t steps) {
 }
 
 void PollardEngine::runWildWalk(const ecpoint &start, uint64_t steps) {
+    runWildWalk(start, steps, std::random_device{}());
+}
+
+void PollardEngine::runWildWalk(const ecpoint &start, uint64_t steps, uint64_t seed) {
     // Wild walk begins from a supplied point and advances by random multiples
     // of G while tracking the corresponding scalar ``k``.  Window constraints
     // are gathered identically to the tame walk.
-    std::mt19937_64 rng(std::random_device{}());
+    std::mt19937_64 rng(seed);
 
     uint64_t maxStep;
     if(_windowBits >= 64) {

--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -37,9 +37,12 @@ public:
     // moduli.
     bool reconstruct(secp256k1::uint256 &out);
 
-    // CPU based tame and wild walks using random steps.
+    // CPU based tame and wild walks using random steps.  The overloads with a
+    // seed parameter enable deterministic behaviour for testing.
     void runTameWalk(const secp256k1::uint256 &start, uint64_t steps);
+    void runTameWalk(const secp256k1::uint256 &start, uint64_t steps, uint64_t seed);
     void runWildWalk(const secp256k1::ecpoint &start, uint64_t steps);
+    void runWildWalk(const secp256k1::ecpoint &start, uint64_t steps, uint64_t seed);
 
 private:
     std::vector<Constraint> _constraints;

--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,14 @@ dir_logger:
 
 dir_addrgen:	dir_cmdparse dir_addressutil dir_secp256k1lib
 	make --directory AddrGen
-dir_clunittest:	dir_clutil
+dir_clunittest: dir_clutil
 	make --directory CLUnitTests
+
+dir_pollardtests: dir_secp256k1lib dir_cryptoutil dir_util
+	make --directory PollardTests
+
+test: dir_pollardtests
+	$(BINDIR)/pollardtests
 
 clean:
 	make --directory AddressUtil clean

--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -1,0 +1,10 @@
+NAME=PollardTests
+CPPSRC=main.cpp
+
+all:
+	${CXX} -o pollardtests.bin ${CPPSRC} ../KeyFinder/PollardEngine.cpp ${INCLUDE} ${CXXFLAGS} ${LIBS} -lsecp256k1 -lcryptoutil -lutil
+	mkdir -p $(BINDIR)
+	cp pollardtests.bin $(BINDIR)/pollardtests
+
+clean:
+	rm -f pollardtests.bin

--- a/PollardTests/main.cpp
+++ b/PollardTests/main.cpp
@@ -1,0 +1,63 @@
+#include <iostream>
+#include <vector>
+#include "PollardEngine.h"
+#include "secp256k1.h"
+using namespace secp256k1;
+
+static uint256 maskBits(unsigned int bits) {
+    uint256 m(0);
+    for(unsigned int i=0;i<bits;i++) {
+        m.v[i/32] |= (1u << (i%32));
+    }
+    return m;
+}
+
+bool testReconstruct() {
+    uint256 key("0x11223344556677889900aabbccddeeff00112233445566778899aabbccddeeff");
+    PollardEngine eng(nullptr, 0, {});
+    for(unsigned int bits=32; bits<=256; bits+=32) {
+        uint256 mask = maskBits(bits);
+        uint256 val;
+        for(int w=0; w<8; ++w) {
+            val.v[w] = key.v[w] & mask.v[w];
+        }
+        eng.addConstraint(bits, val);
+    }
+    uint256 out;
+    return eng.reconstruct(out) && out==key;
+}
+
+bool testTameWalk() {
+    unsigned int windowBits=1;
+    std::vector<unsigned int> offsets;
+    for(unsigned int i=0;i<256;i++) offsets.push_back(i);
+    uint256 start("1");
+    uint256 recovered(0);
+    PollardEngine eng([&](KeySearchResult r){recovered=r.privateKey;}, windowBits, offsets);
+    eng.runTameWalk(start, 50, 12345);
+    return recovered==uint256(5);
+}
+
+bool testWildWalk() {
+    unsigned int windowBits=1;
+    std::vector<unsigned int> offsets;
+    for(unsigned int i=0;i<256;i++) offsets.push_back(i);
+    ecpoint startP = multiplyPoint(uint256("2"), G());
+    uint256 recovered(0);
+    PollardEngine eng([&](KeySearchResult r){recovered=r.privateKey;}, windowBits, offsets);
+    eng.runWildWalk(startP, 50, 12345);
+    return recovered==uint256(3);
+}
+
+int main(){
+    int fails=0;
+    if(!testReconstruct()) { std::cout<<"reconstruct failed"<<std::endl; fails++; }
+    if(!testTameWalk()) { std::cout<<"tame walk failed"<<std::endl; fails++; }
+    if(!testWildWalk()) { std::cout<<"wild walk failed"<<std::endl; fails++; }
+    if(fails==0) {
+        std::cout<<"PASS"<<std::endl;
+    } else {
+        std::cout<<"FAIL"<<std::endl;
+    }
+    return fails;
+}


### PR DESCRIPTION
## Summary
- allow PollardEngine walks to use a fixed RNG seed for deterministic testing
- add Pollard unit tests covering CRT reconstruction and seeded tame/wild walks
- wire new tests into the build with a `make test` target

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688ee1123b10832e8193544a33839996