### PR TITLE
Document Pollard Rho/CRT options

### DIFF
--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -224,11 +224,11 @@ void usage()
     printf("--stride N              Increment by N keys at a time\n");
     printf("--share M/N             Divide the keyspace into N equal shares, process the Mth share\n");
     printf("--continue FILE         Save/load progress from FILE\n");
-    printf("--pollard              Enable Pollard's kangaroo mode\n");
-    printf("--offsets LIST         Comma-separated list of Pollard offsets\n");
-    printf("--window-size N        Window size for Pollard walk\n");
-    printf("--tames N              Number of tame kangaroos\n");
-    printf("--wilds N              Number of wild kangaroos\n");
+    printf("--pollard              Enable CPU-only Pollard Rho/CRT mode\n");
+    printf("--offsets LIST         Comma-separated bit offsets for CRT windows (required)\n");
+    printf("--window-size N        Bits per window (default 8)\n");
+    printf("--tames N              Tame walk steps (0 disables)\n");
+    printf("--wilds N              Wild walk steps (0 disables)\n");
 }
 
 

--- a/README.md
+++ b/README.md
@@ -115,34 +115,31 @@ Use the `-b,` `-t` and `-p` options to specify the number of blocks, threads per
 xxBitCrack.exe -b 32 -t 256 -p 16 1FshYsUh3mqgsG29XpZ23eLjWV8Ur3VwH
 ```
 
-#### Pollard Rho switches
+#### Pollard Rho/CRT
 
-BitCrack also supports Pollard's rho style searches for the discrete
-logarithm problem.  The feature is enabled with the `--pollard` family of
-switches:
-
-```
---pollard DP_BITS[:WALKS][:SEED]
-    Enable Pollard's rho using distinguished points. `DP_BITS` controls how
-    many leading zero bits mark a distinguished point. `WALKS` sets the number
-    of parallel walks (default 1) and `SEED` provides an optional starting
-    seed.
-
---pollard-write FILE
-    Write distinguished points and checkpoint data to `FILE` so a search can be
-    resumed later.
-```
-
-Example:
+BitCrack includes an experimental Pollard Rho implementation that collects
+bit windows during random walks and reconstructs private keys using the
+Chinese Remainder Theorem (CRT).  The CPU-only feature is enabled with the
+following options:
 
 ```
-xxBitCrack.exe --pollard 24:1024 --pollard-write dp.txt 1FshYsUh3mqgsG29XpZ23eLjWV8Ur3VwH
+--pollard              Enable the Pollard Rho/CRT mode
+--offsets LIST         Comma-separated bit offsets for CRT windows (required)
+--window-size N        Number of bits in each window (default 8)
+--tames N              Steps for tame kangaroo walks (0 disables)
+--wilds N              Steps for wild kangaroo walks (0 disables)
 ```
 
-Pollard mode relies on elliptic-curve backends.  When BitCrack is built with
-the optimized `secp256k1` backend (see `secp256k1lib/`), the rho algorithm uses
-that implementation.  Otherwise, it falls back to the pure C++ ECDSA routines in
-`CryptoUtil/`, which do not require libsecp256k1 but are slower.
+The union of all windows must cover 256 bits for a full reconstruction.
+Tame and wild walks run purely on the CPU and are currently best suited for
+small demonstrations or research.
+
+Minimal example:
+
+```
+xxBitCrack.exe --pollard --offsets 0,64,128,192 --window-size 64 \
+              --tames 100000 --wilds 100000 1FshYsUh3mqgsG29XpZ23eLjWV8Ur3VwH
+```
 
 ### Choosing the right parameters for your device
 


### PR DESCRIPTION
## Summary
- Document Pollard Rho/CRT usage and example in README
- Clarify KeyFinder `--help` output for Pollard options

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688ee70cc21c832e9a13965719e66aeb