### PR TITLE
Enable full Pollard segment traversal

### DIFF
--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -521,11 +521,16 @@ int runPollard()
                 engine.runWildWalk(startPoint, wildSteps);
             }
 
-            if(_resultFound || !_config.full) {
+            if(_resultFound) {
                 break;
             }
 
             segmentStart = segmentStart.add(_config.stride);
+            _config.nextKey = segmentStart;
+
+            if(!_config.full) {
+                break;
+            }
         }
     } catch(const std::exception &ex) {
         Logger::log(LogLevel::Error, std::string("Pollard error: ") + ex.what());


### PR DESCRIPTION
## Summary
- Track progress across Pollard segments so `--full` walks advance through the keyspace.
- Populate nextKey after each stride to allow continued segment processing.

## Testing
- `make` *(fails: PollardEngine.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688eefdf34f0832e91c3606783b3c788