### PR TITLE
Build CUDA search device with nvcc

### DIFF
--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -2,21 +2,24 @@ NAME=CudaKeySearchDevice
 CPPSRC:=$(wildcard *.cpp)
 CUSRC:=$(wildcard *.cu)
 
-all:	cuda
+.RECIPEPREFIX := ;
+
+all:    cuda
 
 cuda:
-	for file in ${CPPSRC} ; do\
-		${CXX} -c $$file ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS};\
-	done
+;for file in ${CPPSRC} ; do\
+;;${NVCC} -c $$file -o $$file".o" ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE};\
+;done
 
-	for file in ${CUSRC} ; do\
-		${NVCC} -c $$file -o $$file".o" ${NVCCFLAGS} -rdc=true ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
-	done
+;for file in ${CUSRC} ; do\
+;;${NVCC} -c $$file -o $$file".o" ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
+;done
 
-	${NVCC} -dlink -o cuda_libs.o *.cu.o -lcudadevrt -lcudart
+;${NVCC} -dlink -o cuda_libs.o *.o -lcudadevrt -lcudart
 
-	ar rvs ${LIBDIR}/lib$(NAME).a *.o
+;ar rvs ${LIBDIR}/lib$(NAME).a *.o
 
 clean:
-	rm -f *.o *.cu.o
-	rm -f *.a
+;rm -f *.o
+;rm -f *.a
+

--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -2,9 +2,9 @@ CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
 
 all:
 ifeq ($(BUILD_CUDA), 1)
-	${CXX} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
-	mkdir -p $(BINDIR)
-	cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
+        ${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
+        mkdir -p $(BINDIR)
+        cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif
 ifeq ($(BUILD_OPENCL),1)
 	${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 CUR_DIR=$(shell pwd)
 DIRS=util AddressUtil CmdParse CryptoUtil KeyFinderLib KeyFinder CLKeySearchDevice CudaKeySearchDevice cudaMath clMath clUtil cudaUtil secp256k1lib Logger embedcl
 
@@ -16,6 +15,7 @@ CXXFLAGS=-O2 -std=c++11
 COMPUTE_CAP=89
 NVCC=nvcc
 NVCCFLAGS=-std=c++11 -gencode=arch=compute_${COMPUTE_CAP},code=\"sm_${COMPUTE_CAP}\" -Xptxas="-v" -Xcompiler "${CXXFLAGS}"
+NVCCFLAGS+=-rdc=true
 CUDA_HOME=/usr/local/cuda
 CUDA_LIB=${CUDA_HOME}/lib64
 CUDA_INCLUDE=${CUDA_HOME}/include


### PR DESCRIPTION
## Summary
- build CUDA key search device using `nvcc`
- link KeyFinder with the CUDA object via `nvcc`
- enable relocatable device code for all CUDA builds

## Testing
- `make BUILD_CUDA=1` *(fails: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688efb044154832eb342176e84cf9a7a