### PR TITLE
Fix CUDA Makefile recipe prefix

### DIFF
--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -8,11 +8,11 @@ all:    cuda
 
 cuda:
 ;for file in ${CPPSRC} ; do\
-;;${NVCC} -c $$file -o $$file".o" ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE};\
+;   ${NVCC} -c $$file -o $$file".o" ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE};\
 ;done
 
 ;for file in ${CUSRC} ; do\
-;;${NVCC} -c $$file -o $$file".o" ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
+;   ${NVCC} -c $$file -o $$file".o" ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
 ;done
 
 ;${NVCC} -dlink -o cuda_libs.o *.o -lcudadevrt -lcudart


### PR DESCRIPTION
## Summary
- correct recipe lines in `CudaKeySearchDevice/Makefile` so each starts with a single semicolon

## Testing
- `make BUILD_CUDA=1` *(fails: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688eff11bb74832e9b5d93e0ed04f4ac