### PR TITLE
Fix CUDA source compilation for CudaKeySearchDevice

### DIFF
--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -8,7 +8,7 @@ all:    cuda
 
 cuda:
 ;for file in ${CPPSRC} ; do\
-;   ${NVCC} -c $$file -o $$file".o" ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE};\
+;   ${NVCC} -x cu -c $$file -o $$file".o" ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE};\
 ;done
 
 ;for file in ${CUSRC} ; do\


### PR DESCRIPTION
## Summary
- Treat `CudaKeySearchDevice.cpp` as CUDA source by passing `-x cu` to nvcc so kernel launches like `pollardRandomWalk<<<>>>` compile

## Testing
- `make BUILD_CUDA=1` *(fails: cudaUtil.cpp:4:10: fatal error: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688f085c5384832ea5d06d5cb5f7bd65