### PR TITLE
Include generated OpenCL test source in clunittest build

### DIFF
--- a/CLUnitTests/Makefile
+++ b/CLUnitTests/Makefile
@@ -5,7 +5,7 @@ all:
 	cat ../clMath/secp256k1.cl secp256k1test.cl > cltest.cl
 	${BINDIR}/embedcl cltest.cl cltest.cpp _secp256k1_test_cl
 
-	${CXX} -o clunittest.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lclutil -lutil -lOpenCL
+	${CXX} -o clunittest.bin ${CPPSRC} cltest.cpp ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lclutil -lutil -lOpenCL
 	mkdir -p $(BINDIR)
 
 	cp clunittest.bin $(BINDIR)/clunittest


### PR DESCRIPTION
## Summary
- ensure clunittest links against the generated OpenCL source by compiling `cltest.cpp`

## Testing
- `make BUILD_OPENCL=1` *(fails: CL/cl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688f0c51c63c832e90c0cf1646b5d6e4