### PR TITLE
Use inttypes macros for 64-bit formats

### DIFF
--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <inttypes.h>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -286,7 +287,7 @@ static void printDeviceList(const std::vector<DeviceManager::DeviceInfo> &device
     for(int i = 0; i < devices.size(); i++) {
         printf("ID:     %d\n", devices[i].id);
         printf("Name:   %s\n", devices[i].name.c_str());
-        printf("Memory: %lldMB\n", devices[i].memory / ((uint64_t)1024 * 1024));
+        printf("Memory: %" PRIu64 "MB\n", devices[i].memory / ((uint64_t)1024 * 1024));
         printf("Compute units: %d\n", devices[i].computeUnits);
         printf("\n");
     }

--- a/util/util.cpp
+++ b/util/util.cpp
@@ -1,4 +1,5 @@
 #include<stdio.h>
+#include<inttypes.h>
 #include<string>
 #include<fstream>
 #include<vector>
@@ -57,7 +58,7 @@ namespace util {
 	{
 		char buf[32] = "";
 
-		sprintf(buf, "%lld", x);
+                sprintf(buf, "%" PRIu64, x);
 
 		std::string s(buf);
 
@@ -106,11 +107,11 @@ namespace util {
 		}
 
 		if(isHex) {
-			if(sscanf(s.c_str(), "%llx", &val) != 1) {
+                        if(sscanf(s.c_str(), "%" PRIx64, &val) != 1) {
 				throw std::string("Expected an integer");
 			}
 		} else {
-			if(sscanf(s.c_str(), "%lld", &val) != 1) {
+                        if(sscanf(s.c_str(), "%" PRIu64, &val) != 1) {
 				throw std::string("Expected an integer");
 			}
 		}
@@ -239,7 +240,7 @@ namespace util {
 	{
 		char buf[100] = { 0 };
 
-		sprintf(buf, "%lld", (uint64_t)value);
+                sprintf(buf, "%" PRIu64, (uint64_t)value);
 
 		return std::string(buf);
 	}


### PR DESCRIPTION
## Summary
- Replace `%lld` and `%llx` specifiers with portable `PRIu64` and `PRIx64` macros.
- Include `<inttypes.h>` where needed to support the new macros.

## Testing
- `g++ -std=c++11 -Wformat -Werror=format -c util/util.cpp`
- `g++ -std=c++11 -Wformat -Werror=format -c KeyFinder/main.cpp -IKeyFinderLib -IAddressUtil -Iutil -Isecp256k1lib -ICmdParse -ILogger -IKeyFinder`
- `clang++-19 -std=c++11 -Wformat -Werror=format -c util/util.cpp`
- `clang++-19 -std=c++11 -Wno-everything -Wformat -Werror=format -c KeyFinder/main.cpp -IKeyFinderLib -IAddressUtil -Iutil -Isecp256k1lib -ICmdParse -ILogger -IKeyFinder`


------
https://chatgpt.com/codex/tasks/task_e_688f731cc0c4832e959ef06652f86ff5