### PR TITLE
Add per-thread xorshift128+ RNG for Pollard kernels

### DIFF
--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -6,20 +6,35 @@ struct CudaPollardMatch {
     unsigned int hash[5];
 };
 
-__device__ static unsigned long long xorshift64(unsigned long long &state)
+struct RNGState {
+    unsigned long long s0;
+    unsigned long long s1;
+};
+
+__device__ static inline unsigned long long xorshift128plus(RNGState &state)
 {
-    state ^= state << 13;
-    state ^= state >> 7;
-    state ^= state << 17;
-    return state;
+    unsigned long long x = state.s0;
+    unsigned long long y = state.s1;
+    state.s0 = y;
+    x ^= x << 23;
+    x ^= x >> 17;
+    x ^= y;
+    x ^= y >> 26;
+    state.s1 = x;
+    return x + y;
+}
+
+__device__ static inline unsigned long long next_random_step(RNGState &state)
+{
+    const unsigned long long ORDER_MINUS_ONE = 0xBFD25E8CD0364140ULL;
+    return (xorshift128plus(state) % ORDER_MINUS_ONE) + 1ULL;
 }
 
 __device__ static void fakeHash160(unsigned long long k, unsigned int hash[5])
 {
-    unsigned long long x = k;
+    RNGState st{ k, k ^ 0x9E3779B97F4A7C15ULL };
     for(int i = 0; i < 5; i++) {
-        xorshift64(x);
-        hash[i] = static_cast<unsigned int>(x);
+        hash[i] = static_cast<unsigned int>(xorshift128plus(st));
     }
 }
 
@@ -31,13 +46,15 @@ extern "C" __global__ void pollardRandomWalk(CudaPollardMatch *out,
                                               unsigned int windowBits)
 {
     if(threadIdx.x == 0 && blockIdx.x == 0) {
-        unsigned long long state = seed;
+        RNGState rng{ seed ^ 1ULL, seed + 1ULL };
         unsigned long long scalar = 0ULL;
+        const unsigned long long ORDER = 0xBFD25E8CD0364141ULL;
         unsigned long long mask = (windowBits >= 64) ? 0xffffffffffffffffULL : ((1ULL << windowBits) - 1ULL);
         unsigned int count = 0;
         for(unsigned int i = 0; i < steps && count < maxOut; i++) {
-            unsigned long long step = (xorshift64(state) & mask) + 1ULL;
+            unsigned long long step = next_random_step(rng);
             scalar += step;
+            scalar %= ORDER;
             if((scalar & mask) == 0ULL) {
                 fakeHash160(scalar, out[count].hash);
                 out[count].k[0] = scalar & 0xffffffffULL;


### PR DESCRIPTION
## Summary
- use per-thread xorshift128+ RNG in CUDA and OpenCL Pollard walk kernels
- add `next_random_step` helper for uniform scalar steps
- update Pollard tests for new deterministic output

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688f79593294832eb6c6b70b7ce43fa9