### PR TITLE
Add RIPEMD160 hash for compressed keys

### DIFF
--- a/AddressUtil/AddressUtil.h
+++ b/AddressUtil/AddressUtil.h
@@ -23,11 +23,12 @@ namespace Base58 {
 namespace Hash {
 
 
-	void hashPublicKey(const secp256k1::ecpoint &p, unsigned int *digest);
-	void hashPublicKeyCompressed(const secp256k1::ecpoint &p, unsigned int *digest);
+        void hashPublicKey(const secp256k1::ecpoint &p, unsigned int *digest);
+        void hashPublicKeyCompressed(const secp256k1::ecpoint &p, unsigned int *digest);
 
-	void hashPublicKey(const unsigned int *x, const unsigned int *y, unsigned int *digest);
-	void hashPublicKeyCompressed(const unsigned int *x, const unsigned int *y, unsigned int *digest);
+        void hashPublicKey(const unsigned int *x, const unsigned int *y, unsigned int *digest);
+        void hashPublicKeyCompressed(const unsigned int *x, const unsigned int *y, unsigned int *digest);
+        void hashPublicKeyCompressed(const unsigned char *key, unsigned int *digest);
 
 };
 


### PR DESCRIPTION
## Summary
- expose new helper to hash compressed public keys
- implement RIPEMD160(SHA256(pubkey)) for 33-byte compressed key producing 5-word hash160

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688f7e211eb0832e8bfeb117361d616f