### PR TITLE
Clarify includes for Pollard hashing

### DIFF
--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -1,8 +1,8 @@
 #include <stdint.h>
 #include "../KeyFinder/PollardTypes.h"
-#include "sha256.cuh"
-#include "ripemd160.cuh"
-#include "secp256k1.cuh"
+#include "sha256.cuh"   // SHA256 hashing for public keys
+#include "ripemd160.cuh" // RIPEMD160 finalisation
+#include "secp256k1.cuh" // EC point operations
 
 struct CudaPollardMatch {
     unsigned long long k[4];


### PR DESCRIPTION
## Summary
- clarify hashing/point-op includes in CUDA pollard random walk

## Testing
- `make test`
- `make BUILD_CUDA=1 dir_cudaKeySearchDevice` (fails: cuda.h: No such file or directory)
- `apt-get update` (fails: repositories not signed)


------
https://chatgpt.com/codex/tasks/task_e_688f87a34908832e8310786ba9f0c58b