### PR TITLE
Include AddressUtil header for CLPollardDevice

### DIFF
--- a/CLKeySearchDevice/CLPollardDevice.cpp
+++ b/CLKeySearchDevice/CLPollardDevice.cpp
@@ -2,6 +2,7 @@
 #include <random>
 #include <limits>
 #include <cstring>
+#include "AddressUtil.h"
 
 using namespace secp256k1;
 


### PR DESCRIPTION
## Summary
- include AddressUtil.h so Hash namespace symbols are available in CLPollardDevice

## Testing
- `make dir_clKeySearchDevice BUILD_OPENCL=1` *(fails: CL/cl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688f8a9ade44832ea7839e8d88a6ff0d