### PR TITLE
Replace std::make_unique to support C++11 build

### DIFF
--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -524,12 +524,12 @@ int runPollard()
 
 #ifdef BUILD_CUDA
             if(_devices[_config.device].type == DeviceManager::DeviceType::CUDA) {
-                engine.setDevice(std::make_unique<CudaPollardDevice>(engine, window, offsets, targetHashes));
+                engine.setDevice(std::unique_ptr<CudaPollardDevice>(new CudaPollardDevice(engine, window, offsets, targetHashes)));
             }
 #endif
 #ifdef BUILD_OPENCL
             if(_devices[_config.device].type == DeviceManager::DeviceType::OpenCL) {
-                engine.setDevice(std::make_unique<CLPollardDevice>(engine, window, offsets, targetHashes));
+                engine.setDevice(std::unique_ptr<CLPollardDevice>(new CLPollardDevice(engine, window, offsets, targetHashes)));
             }
 #endif
 


### PR DESCRIPTION
## Summary
- avoid C++14-only `std::make_unique` in `KeyFinder/main.cpp` by creating `std::unique_ptr` with `new`

## Testing
- `make BUILD_CUDA=0 BUILD_OPENCL=0`
- `g++ -DBUILD_OPENCL -c KeyFinder/main.cpp` *(fails: `CL/cl.h` missing)*
- `g++ -DBUILD_CUDA -c KeyFinder/main.cpp` *(fails: `cuda_runtime.h` missing)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688f91efac74832e85cec5ac31af3c82