### PR TITLE
Add CPU-only build option

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -11,7 +11,13 @@ ifeq ($(BUILD_OPENCL),1)
 	mkdir -p $(BINDIR)
 	cp clKeyFinder.bin $(BINDIR)/clBitCrack
 endif
+ifeq ($(CPU),1)
+	${CXX} -o KeyFinder.bin ${CPPSRC} ${INCLUDE} ${CXXFLAGS} ${LIBS} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -llogger -lutil -lcmdparse -pthread
+	mkdir -p $(BINDIR)
+	cp KeyFinder.bin $(BINDIR)/BitCrack
+endif
 
 clean:
 	rm -rf cuKeyFinder.bin
 	rm -rf clKeyFinder.bin
+	rm -rf KeyFinder.bin

--- a/KeyFinderLib/Makefile
+++ b/KeyFinderLib/Makefile
@@ -1,15 +1,20 @@
 NAME=keyfinder
 CPPSRC:=$(wildcard *.cpp)
 
-all:	cuda
-
-cuda:
-	for file in ${CPPSRC} ; do\
-		${CXX} -c $$file ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS};\
+all:
+ifeq ($(CPU),1)
+	for file in ${CPPSRC} ; do \
+	${CXX} -c $$file ${INCLUDE} ${CXXFLAGS}; \
 	done
+else
+	for file in ${CPPSRC} ; do \
+	${CXX} -c $$file ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS}; \
+	done
+endif
 
 	ar rvs ${LIBDIR}/lib$(NAME).a *.o
 
 clean:
 	rm -f *.o *.cu.o
 	rm -f *.a
+

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ xxBitCrack.exe -b 32 -t 256 -p 16 1FshYsUh3mqgsG29XpZ23eLjWV8Ur3VwH
 
 BitCrack includes an experimental Pollard Rho implementation that collects
 bit windows during random walks and reconstructs private keys using the
-Chinese Remainder Theorem (CRT).  The CPU-only feature is enabled with the
-following options:
+Chinese Remainder Theorem (CRT).  Build the CPU-only components with `make CPU=1`
+or `make cpu`. The feature is enabled with the following options:
 
 ```
 --pollard              Enable the Pollard Rho/CRT mode
@@ -196,6 +196,11 @@ make BUILD_OPENCL=1
 Or build both:
 ```
 make BUILD_CUDA=1 BUILD_OPENCL=1
+```
+
+Build CPU-only Pollard/CRT components:
+```
+make CPU=1
 ```
 
 ### Python Pollard Rho/Kangaroo utility


### PR DESCRIPTION
## Summary
- add CPU flag and target to build only Pollard/CRT components
- compile KeyFinder and libraries without GPU dependencies
- document CPU-only build in README

## Testing
- `make CPU=1`
- `./bin/pollardtests`


------
https://chatgpt.com/codex/tasks/task_e_688f9641510c832e99ea03dbf7ad3325