### PR TITLE
GPU windows: hash once per step

### DIFF
--- a/CudaKeySearchDevice/CudaPollardDevice.h
+++ b/CudaKeySearchDevice/CudaPollardDevice.h
@@ -10,9 +10,6 @@ class CudaPollardDevice : public PollardDevice {
     unsigned int _windowBits;
     std::vector<unsigned int> _offsets;
     std::vector<std::array<unsigned int,5>> _targets;
-
-    static secp256k1::uint256 maskBits(unsigned int bits);
-    static uint64_t hashWindowLE(const unsigned int h[5], unsigned int offset, unsigned int bits);
 public:
     CudaPollardDevice(PollardEngine &engine,
                       unsigned int windowBits,


### PR DESCRIPTION
## Summary
- Compute RIPEMD160 every step in OpenCL and CUDA Pollard walks and match host-specified hash windows, emitting `PollardWindow` entries with scalar fragments.
- Introduce target window descriptors and atomic output of matches in both GPU kernels.
- Update CUDA device host code to build window descriptors, launch revised kernels, and forward results to the engine.

## Testing
- `make -C PollardTests`
- `./PollardTests/pollardtests`


------
https://chatgpt.com/codex/tasks/task_e_688fe5675578832e879a74923142ab89