### PR TITLE
Fix duplicate cltest.cpp in CLUnitTests Makefile

### DIFF
--- a/CLUnitTests/Makefile
+++ b/CLUnitTests/Makefile
@@ -1,5 +1,6 @@
 NAME=CLUnitTests
-CPPSRC:=$(wildcard *.cpp)
+# Exclude the generated cltest.cpp to avoid duplicate compilation
+CPPSRC:=$(filter-out cltest.cpp,$(wildcard *.cpp))
 
 all:
 	cat ../clMath/secp256k1.cl secp256k1test.cl > cltest.cl


### PR DESCRIPTION
## Summary
- prevent generated `cltest.cpp` from being compiled twice in CLUnitTests

## Testing
- `make dir_clunittest BUILD_OPENCL=1` *(fails: CL/cl.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_688fea80ed6c832e8b3d74b992051432