### PR TITLE
Add search range and candidate verification to PollardEngine

### DIFF
--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -47,6 +47,8 @@ public:
                   unsigned int windowBits,
                   const std::vector<unsigned int> &offsets,
                   const std::vector<std::array<unsigned int,5>> &targets,
+                  const secp256k1::uint256 &L,
+                  const secp256k1::uint256 &U,
                   unsigned int batchSize = 1024,
                   unsigned int pollInterval = 100);
 
@@ -57,7 +59,8 @@ public:
     // Attempt to reconstruct the private key for ``target`` from accumulated
     // constraints using a CRT solver capable of combining arbitrarily large
     // power-of-two moduli.
-    bool reconstruct(size_t target, secp256k1::uint256 &out);
+    bool reconstruct(size_t target, secp256k1::uint256 &k0,
+                     secp256k1::uint256 &modulus);
 
     // Consume a window result produced by a GPU kernel or converted from a
     // CPU device.  This function accumulates the constraint, attempts key
@@ -94,6 +97,8 @@ private:
 
     unsigned int _batchSize;                  // windows processed per poll
     unsigned int _pollInterval;               // milliseconds between polls
+    secp256k1::uint256 _L;                    // search lower bound
+    secp256k1::uint256 _U;                    // search upper bound
 
     // Metrics
     uint64_t _windowsProcessed = 0;           // number of windows consumed
@@ -104,6 +109,10 @@ private:
     bool checkPoint(const secp256k1::ecpoint &p);
     void enumerateCandidate(const secp256k1::uint256 &priv,
                             const secp256k1::ecpoint &pub);
+    void enumerateCandidates(const secp256k1::uint256 &k0,
+                             const secp256k1::uint256 &modulus,
+                             const secp256k1::uint256 &L,
+                             const secp256k1::uint256 &U);
     void handleMatch(const PollardMatch &m);
     void pollDevice();
 

--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -526,6 +526,7 @@ int runPollard()
     try {
         while(segmentStart.cmp(_config.endKey) <= 0) {
             PollardEngine engine(resultCallback, window, offsets, targetHashes,
+                                 segmentStart, _config.endKey,
                                  _config.pollBatch, _config.pollInterval);
 
 #ifdef BUILD_CUDA


### PR DESCRIPTION
## Summary
- expose search limits (L/U) in `PollardEngine` and store them for candidate enumeration
- extend CRT reconstruction to always yield base and modulus, enabling range enumeration
- enumerate and verify candidates against target hashes before invoking callbacks

## Testing
- `make cpu`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689004b68d9c832e969f65e3eb0a53f6