### PR TITLE
Fix duplicate cltest compilation in unit tests

### DIFF
--- a/CLUnitTests/Makefile
+++ b/CLUnitTests/Makefile
@@ -1,12 +1,10 @@
 NAME=CLUnitTests
-# Exclude the generated cltest.cpp to avoid duplicate compilation
-CPPSRC:=$(filter-out cltest.cpp,$(wildcard *.cpp))
+CPPSRC:=$(wildcard *.cpp)
 
 all:
 	cat ../clMath/secp256k1.cl secp256k1test.cl > cltest.cl
 	${BINDIR}/embedcl cltest.cl cltest.cpp _secp256k1_test_cl
-
-	${CXX} -o clunittest.bin ${CPPSRC} cltest.cpp ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lclutil -lutil -lOpenCL
+	${CXX} -o clunittest.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lclutil -lutil -lOpenCL
 	mkdir -p $(BINDIR)
 
 	cp clunittest.bin $(BINDIR)/clunittest


### PR DESCRIPTION
## Summary
- simplify CLUnitTests Makefile to avoid compiling cltest.cpp twice

## Testing
- `make dir_embedcl dir_clunittest` *(fails: CL/cl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68900e23c20c832e8b8e764e1525778d