### PR TITLE
Make RIPEMD160 final round device function private

### DIFF
--- a/CudaKeySearchDevice/CudaKeySearchDevice.cu
+++ b/CudaKeySearchDevice/CudaKeySearchDevice.cu
@@ -24,7 +24,7 @@ __constant__ unsigned int *_CHAIN[1];
 static unsigned int *_chainBufferPtr = NULL;
 
 
-__device__ void doRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5])
+static __device__ __forceinline__ void doRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5])
 {
     const unsigned int iv[5] = {
         0x67452301,

--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -46,7 +46,7 @@ __device__ static inline unsigned long long next_random_step(RNGState &state)
     return (xorshift128plus(state) % ORDER_MINUS_ONE) + 1ULL;
 }
 
-__device__ void doRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5])
+static __device__ __forceinline__ void doRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5])
 {
     const unsigned int iv[5] = {
         0x67452301,


### PR DESCRIPTION
## Summary
- inline RIPEMD160 final round in CUDA key search
- inline RIPEMD160 final round in CUDA Pollard kernel

## Testing
- `make BUILD_CUDA=1 test`
- `make BUILD_CUDA=1 dir_cudaKeySearchDevice` *(fails: cudaUtil.h:4:10: fatal error: cuda.h: No such file or directory)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed.)*


------
https://chatgpt.com/codex/tasks/task_e_68901f66688c832e992c84124c6beaf1