### PR TITLE
Make CLPollardDevice hash helpers public

### DIFF
--- a/CLKeySearchDevice/CLPollardDevice.h
+++ b/CLKeySearchDevice/CLPollardDevice.h
@@ -10,14 +10,14 @@ class CLPollardDevice : public PollardDevice {
     unsigned int _windowBits;
     std::vector<unsigned int> _offsets;
     std::vector<std::array<unsigned int,5>> _targets;
-
-    static secp256k1::uint256 maskBits(unsigned int bits);
-    static uint64_t hashWindowLE(const unsigned int h[5], unsigned int offset, unsigned int bits);
 public:
     CLPollardDevice(PollardEngine &engine,
                     unsigned int windowBits,
                     const std::vector<unsigned int> &offsets,
                     const std::vector<std::array<unsigned int,5>> &targets);
+
+    static secp256k1::uint256 maskBits(unsigned int bits);
+    static uint64_t hashWindowLE(const unsigned int h[5], unsigned int offset, unsigned int bits);
 
     void startTameWalk(const secp256k1::uint256 &start, uint64_t steps,
                        uint64_t seed, bool sequential) override;


### PR DESCRIPTION
## Summary
- expose CLPollardDevice::maskBits and ::hashWindowLE as public helpers

## Testing
- `make BUILD_OPENCL=1 dir_clKeySearchDevice` *(fails: CL/cl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68902a0cbae4832e8afe9646fe10ef07