### PR TITLE
Remove redundant callback check in PollardEngine

### DIFF
--- a/KeyFinder/PollardEngine.cpp
+++ b/KeyFinder/PollardEngine.cpp
@@ -360,10 +360,6 @@ void PollardEngine::enumerateCandidate(const uint256 &priv, const ecpoint &pub) 
 
     _reconstructionSuccess++;
 
-    if(!_callback) {
-        return;
-    }
-
     KeySearchResult r;
     r.privateKey = priv;
     r.publicKey = pub;


### PR DESCRIPTION
## Summary
- remove redundant `_callback` null check in `PollardEngine::enumerateCandidate`

## Testing
- `make cpu -j8`

------
https://chatgpt.com/codex/tasks/task_e_68902b94c0c8832e8a845c303fe35704