### PR TITLE
Add secp256k1 scalar base multiply test

### DIFF
--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -3,7 +3,7 @@ CPPSRC=main.cpp
 BINDIR?=.
 
 all:
-	${CXX} -o pollardtests.bin ${CPPSRC} ${CXXFLAGS}
+	${CXX} -o pollardtests.bin ${CPPSRC} ${INCLUDE} ${CXXFLAGS} ${LIBS} -laddressutil -lsecp256k1 -lcryptoutil
 	mkdir -p $(BINDIR)
 	cp pollardtests.bin $(BINDIR)/pollardtests
 


### PR DESCRIPTION
## Summary
- add `testScalarOne` to verify base-point scalar multiplication and RIPEMD160 hash
- link PollardTests with required crypto and secp256k1 libraries

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68902c58692c832ebf71a071a525d14f