### PR TITLE
Add GPU scalar one test

### DIFF
--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -1,11 +1,37 @@
 NAME=PollardTests
 CPPSRC=main.cpp
+CUDASRC=cuda_scalar_one.cu
 BINDIR?=.
 
-all:
-	${CXX} -o pollardtests.bin ${CPPSRC} ${INCLUDE} ${CXXFLAGS} ${LIBS} -laddressutil -lsecp256k1 -lcryptoutil
-	mkdir -p $(BINDIR)
-	cp pollardtests.bin $(BINDIR)/pollardtests
+BUILD_CUDA?=0
+BUILD_OPENCL?=0
+BUILD_CUDA:=$(if $(BUILD_CUDA),$(BUILD_CUDA),0)
+BUILD_OPENCL:=$(if $(BUILD_OPENCL),$(BUILD_OPENCL),0)
+
+.RECIPEPREFIX := ;
+
+OBJS=
+ifeq ($(BUILD_CUDA),1)
+OBJS+=cuda_scalar_one.o
+endif
+
+CXXFLAGS+=-DBUILD_CUDA=$(BUILD_CUDA) -DBUILD_OPENCL=$(BUILD_OPENCL)
+
+LIBS_LOCAL=-laddressutil -lsecp256k1 -lcryptoutil
+ifeq ($(BUILD_OPENCL),1)
+LIBS_LOCAL+=-lclutil -lutil -lOpenCL -L${OPENCL_LIB}
+endif
+ifeq ($(BUILD_CUDA),1)
+LIBS_LOCAL+=-lcudart -L${CUDA_LIB}
+endif
+
+all: $(OBJS)
+;${CXX} -o pollardtests.bin ${CPPSRC} $(OBJS) ${INCLUDE} ${CXXFLAGS} ${LIBS} ${LIBS_LOCAL}
+;mkdir -p $(BINDIR)
+;cp pollardtests.bin $(BINDIR)/pollardtests
+
+cuda_scalar_one.o: cuda_scalar_one.cu
+;${NVCC} -c cuda_scalar_one.cu -o cuda_scalar_one.o ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
 
 clean:
-	rm -f pollardtests.bin
+;rm -f pollardtests.bin cuda_scalar_one.o

--- a/PollardTests/cuda_scalar_one.cu
+++ b/PollardTests/cuda_scalar_one.cu
@@ -1,0 +1,184 @@
+#include <cuda_runtime.h>
+#include "../cudaMath/secp256k1.cuh"
+#include "../cudaMath/sha256.cuh"
+#include "../cudaMath/ripemd160.cuh"
+
+__device__ static void doRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5])
+{
+    const unsigned int iv[5] = {
+        0x67452301,
+        0xefcdab89,
+        0x98badcfe,
+        0x10325476,
+        0xc3d2e1f0
+    };
+    for(int i = 0; i < 5; i++) {
+        hOut[i] = endian(hIn[i] + iv[(i + 1) % 5]);
+    }
+}
+
+__device__ void hashPublicKeyCompressed(const unsigned int *x, unsigned int yParity, unsigned int *digestOut)
+{
+    unsigned int hash[8];
+    sha256PublicKeyCompressed(x, yParity, hash);
+    for(int i = 0; i < 8; i++) {
+        hash[i] = endian(hash[i]);
+    }
+    ripemd160sha256NoFinal(hash, digestOut);
+}
+
+__device__ static void setPointInfinity(unsigned int x[8], unsigned int y[8])
+{
+    for(int i = 0; i < 8; i++) {
+        x[i] = 0xffffffff;
+        y[i] = 0xffffffff;
+    }
+}
+
+__device__ static void pointDouble(const unsigned int x[8], const unsigned int y[8], unsigned int rx[8], unsigned int ry[8])
+{
+    if(isInfinity(x)) {
+        setPointInfinity(rx, ry);
+        return;
+    }
+
+    unsigned int x2[8];
+    unsigned int three_x2[8];
+    unsigned int two_y[8];
+    unsigned int inv[8];
+    unsigned int lambda[8];
+    unsigned int lambda2[8];
+    unsigned int k[8];
+
+    mulModP(x, x, x2);
+    addModP(x2, x2, three_x2);
+    addModP(three_x2, x2, three_x2);
+
+    addModP(y, y, two_y);
+    invModP(two_y, inv);
+    mulModP(three_x2, inv, lambda);
+
+    mulModP(lambda, lambda, lambda2);
+    subModP(lambda2, x, rx);
+    subModP(rx, x, rx);
+
+    subModP(x, rx, k);
+    mulModP(lambda, k, ry);
+    subModP(ry, y, ry);
+}
+
+__device__ static void pointAdd(const unsigned int ax[8], const unsigned int ay[8],
+                                const unsigned int bx[8], const unsigned int by[8],
+                                unsigned int rx[8], unsigned int ry[8])
+{
+    if(isInfinity(ax)) {
+        copyBigInt(bx, rx);
+        copyBigInt(by, ry);
+        return;
+    }
+    if(isInfinity(bx)) {
+        copyBigInt(ax, rx);
+        copyBigInt(ay, ry);
+        return;
+    }
+    if(equal(ax, bx) && equal(ay, by)) {
+        pointDouble(ax, ay, rx, ry);
+        return;
+    }
+
+    unsigned int rise[8];
+    unsigned int run[8];
+    unsigned int inv[8];
+    unsigned int lambda[8];
+    unsigned int lambda2[8];
+    unsigned int k[8];
+
+    subModP(by, ay, rise);
+    subModP(bx, ax, run);
+    invModP(run, inv);
+    mulModP(rise, inv, lambda);
+
+    mulModP(lambda, lambda, lambda2);
+    subModP(lambda2, ax, rx);
+    subModP(rx, bx, rx);
+
+    subModP(ax, rx, k);
+    mulModP(lambda, k, ry);
+    subModP(ry, ay, ry);
+}
+
+__device__ static void scalarMultiplyBase(unsigned long long k, unsigned int rx[8], unsigned int ry[8])
+{
+    setPointInfinity(rx, ry);
+    if(k == 0ULL) {
+        return;
+    }
+
+    unsigned int qx[8];
+    unsigned int qy[8];
+    copyBigInt(_GX, qx);
+    copyBigInt(_GY, qy);
+
+    while(k) {
+        if(k & 1ULL) {
+            unsigned int tx[8];
+            unsigned int ty[8];
+            pointAdd(rx, ry, qx, qy, tx, ty);
+            copyBigInt(tx, rx);
+            copyBigInt(ty, ry);
+        }
+        k >>= 1ULL;
+        if(k) {
+            unsigned int tx[8];
+            unsigned int ty[8];
+            pointDouble(qx, qy, tx, ty);
+            copyBigInt(tx, qx);
+            copyBigInt(ty, qy);
+        }
+    }
+}
+
+__global__ void scalarOneKernel(unsigned int *outX, unsigned int *outY, unsigned int *outHash)
+{
+    unsigned int x[8];
+    unsigned int y[8];
+    scalarMultiplyBase(1ULL, x, y);
+
+    unsigned int digest[5];
+    unsigned int finalHash[5];
+    hashPublicKeyCompressed(x, y[7] & 1U, digest);
+    doRMD160FinalRound(digest, finalHash);
+
+    for(int i = 0; i < 8; i++) {
+        outX[i] = x[i];
+        outY[i] = y[i];
+    }
+    for(int i = 0; i < 5; i++) {
+        outHash[i] = finalHash[i];
+    }
+}
+
+extern "C" bool runCudaScalarOne(unsigned int x[8], unsigned int y[8], unsigned int hash[5])
+{
+    unsigned int *d_x = nullptr;
+    unsigned int *d_y = nullptr;
+    unsigned int *d_hash = nullptr;
+    if(cudaMalloc(&d_x, sizeof(unsigned int) * 8)) return false;
+    if(cudaMalloc(&d_y, sizeof(unsigned int) * 8)) { cudaFree(d_x); return false; }
+    if(cudaMalloc(&d_hash, sizeof(unsigned int) * 5)) { cudaFree(d_x); cudaFree(d_y); return false; }
+
+    scalarOneKernel<<<1,1>>>(d_x, d_y, d_hash);
+    if(cudaDeviceSynchronize() != cudaSuccess) {
+        cudaFree(d_x); cudaFree(d_y); cudaFree(d_hash);
+        return false;
+    }
+    if(cudaMemcpy(x, d_x, sizeof(unsigned int) * 8, cudaMemcpyDeviceToHost)) { cudaFree(d_x); cudaFree(d_y); cudaFree(d_hash); return false; }
+    if(cudaMemcpy(y, d_y, sizeof(unsigned int) * 8, cudaMemcpyDeviceToHost)) { cudaFree(d_x); cudaFree(d_y); cudaFree(d_hash); return false; }
+    if(cudaMemcpy(hash, d_hash, sizeof(unsigned int) * 5, cudaMemcpyDeviceToHost)) { cudaFree(d_x); cudaFree(d_y); cudaFree(d_hash); return false; }
+
+    cudaFree(d_x);
+    cudaFree(d_y);
+    cudaFree(d_hash);
+    return true;
+}
+

--- a/PollardTests/main.cpp
+++ b/PollardTests/main.cpp
@@ -2,7 +2,18 @@
 #include <vector>
 #include <array>
 #include <cstdint>
+#include <fstream>
 #include "AddressUtil.h"
+
+#if BUILD_CUDA
+#include <cuda_runtime.h>
+bool runCudaScalarOne(unsigned int x[8], unsigned int y[8], unsigned int hash[5]);
+#endif
+
+#if BUILD_OPENCL
+#include "clutil.h"
+#include "clContext.h"
+#endif
 
 struct RefMatch {
     uint64_t k;
@@ -99,10 +110,92 @@ bool testScalarOne() {
     return true;
 }
 
+static bool runOpenCLScalarOne(unsigned int x[8], unsigned int y[8], unsigned int hash[5]) {
+#if BUILD_OPENCL
+    try {
+        auto devices = cl::getDevices();
+        if(devices.empty()) return false;
+        cl::CLContext ctx(devices[0].id);
+
+        auto readFile = [](const char *path){
+            std::ifstream f(path); return std::string((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+        };
+        std::string sha = readFile("clMath/sha256.cl");
+        std::string secp = readFile("clMath/secp256k1.cl");
+        std::string rmd = readFile("clMath/ripemd160.cl");
+        std::string pollard = readFile("CLKeySearchDevice/clPollard.cl");
+        std::string src = sha + secp + rmd + pollard + R"(
+        __kernel void scalar_one(__global uint* xOut, __global uint* yOut, __global uint* hOut) {
+            uint px[8]; uint py[8]; uint digest[5];
+            scalarMultiplyBase((ulong)1, px, py);
+            hashPublicKeyCompressed(px, py[7], digest);
+            for(int i=0;i<8;i++){ xOut[i]=px[i]; yOut[i]=py[i]; }
+            for(int j=0;j<5;j++){ hOut[j]=digest[j]; }
+        }
+        )";
+        cl::CLProgram prog(ctx, src.c_str());
+        cl::CLKernel k(prog, "scalar_one");
+        cl_mem dx = ctx.malloc(sizeof(unsigned int)*8);
+        cl_mem dy = ctx.malloc(sizeof(unsigned int)*8);
+        cl_mem dh = ctx.malloc(sizeof(unsigned int)*5);
+        k.set_args(dx, dy, dh);
+        k.call(1,1);
+        ctx.copyDeviceToHost(dx, x, sizeof(unsigned int)*8);
+        ctx.copyDeviceToHost(dy, y, sizeof(unsigned int)*8);
+        ctx.copyDeviceToHost(dh, hash, sizeof(unsigned int)*5);
+        ctx.free(dx); ctx.free(dy); ctx.free(dh);
+        return true;
+    } catch(cl::CLException &) {
+        return false;
+    }
+#else
+    (void)x; (void)y; (void)hash; return false;
+#endif
+}
+
+bool testGpuScalarOne() {
+    unsigned int expectedHash[5] = {
+        0x751e76e8u, 0x199196d4u, 0x54941c45u, 0xd1b3a323u, 0xf1433bd6u
+    };
+    secp256k1::ecpoint G = secp256k1::G();
+    unsigned int gx[8];
+    unsigned int gy[8];
+    G.x.exportWords(gx, 8, secp256k1::uint256::BigEndian);
+    G.y.exportWords(gy, 8, secp256k1::uint256::BigEndian);
+
+    bool ran = false;
+    bool pass = true;
+
+#if BUILD_CUDA
+    int cudaDevs = 0;
+    if(cudaGetDeviceCount(&cudaDevs) == cudaSuccess && cudaDevs > 0) {
+        ran = true;
+        unsigned int x[8], y[8], h[5];
+        if(!runCudaScalarOne(x, y, h)) return false;
+        for(int i=0;i<8;i++){ if(x[i]!=gx[i] || y[i]!=gy[i]) pass=false; }
+        for(int i=0;i<5;i++){ if(h[i]!=expectedHash[i]) pass=false; }
+    }
+#endif
+#if BUILD_OPENCL
+    unsigned int xcl[8], ycl[8], hcl[5];
+    if(runOpenCLScalarOne(xcl, ycl, hcl)) {
+        ran = true;
+        for(int i=0;i<8;i++){ if(xcl[i]!=gx[i] || ycl[i]!=gy[i]) pass=false; }
+        for(int i=0;i<5;i++){ if(hcl[i]!=expectedHash[i]) pass=false; }
+    }
+#endif
+    if(!ran) {
+        std::cout << "GPU test skipped" << std::endl;
+        return true;
+    }
+    return pass;
+}
+
 int main(){
     int fails=0;
     if(!testScalarOne()) { std::cout<<"scalar one failed"<<std::endl; fails++; }
     if(!testDeterministicSeed()) { std::cout<<"deterministic seed failed"<<std::endl; fails++; }
+    if(!testGpuScalarOne()) { std::cout<<"gpu scalar one failed"<<std::endl; fails++; }
     if(fails==0) {
         std::cout<<"PASS"<<std::endl;
     } else {


### PR DESCRIPTION
## Summary
- add CUDA and OpenCL helper to compute public key and hash for scalar 1
- verify GPU results against secp256k1 base point and known hash
- build PollardTests with optional CUDA/OpenCL support

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68902df46f98832ea5c9005343e9b074