### PR TITLE
Include NVCC flags during device linking

### DIFF
--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -22,7 +22,7 @@ cuda:
 ;   ${NVCC} -c $$file -o $$base".o" ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
 ;done
 
-;${NVCC} -dlink -o cuda_libs.o *.o -lcudadevrt -lcudart
+;${NVCC} ${NVCCFLAGS} -dlink -o cuda_libs.o *.o -lcudadevrt -lcudart
 
 ;ar rvs ${LIBDIR}/lib$(NAME).a *.o
 


### PR DESCRIPTION
## Summary
- ensure device linking step respects NVCC flags by forwarding `NVCCFLAGS` to `nvcc -dlink`

## Testing
- `make dir_cudaKeySearchDevice` *(fails: cudaUtil.cpp: fatal error: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689049f84ce0832ea1d5f96c6e390c11