### PR TITLE
Support wider Pollard hash windows

### DIFF
--- a/CLKeySearchDevice/CLPollardDevice.h
+++ b/CLKeySearchDevice/CLPollardDevice.h
@@ -19,7 +19,7 @@ public:
                     bool debug);
 
     static secp256k1::uint256 maskBits(unsigned int bits);
-    static uint64_t hashWindowLE(const unsigned int h[5], unsigned int offset, unsigned int bits);
+    static secp256k1::uint256 hashWindowLE(const unsigned int h[5], unsigned int offset, unsigned int bits);
 
     void startTameWalk(const secp256k1::uint256 &start, uint64_t steps,
                        uint64_t seed, bool sequential) override;

--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -122,8 +122,8 @@ private:
     void handleMatch(const PollardMatch &m);
     void pollDevice();
 
-    static uint64_t hashWindow(const unsigned int h[5], unsigned int offset,
-                               unsigned int bits);
+    static secp256k1::uint256 hashWindow(const unsigned int h[5], unsigned int offset,
+                                         unsigned int bits);
 };
 
 #endif


### PR DESCRIPTION
## Summary
- extend hashWindowLE to return 160-bit uint256 values
- carry wider target windows through CUDA/OpenCL Pollard kernels
- compare and mask multi-word windows correctly on CPU and GPU

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68904e0a4f80832eb7b69ae5d322275d