### PR TITLE
Normalize hash160 endianness

### DIFF
--- a/CLKeySearchDevice/CLKeySearchDevice.cpp
+++ b/CLKeySearchDevice/CLKeySearchDevice.cpp
@@ -36,7 +36,7 @@ static void undoRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5]
     };
 
     for(int i = 0; i < 5; i++) {
-        hOut[i] = util::endian(hIn[i]) - iv[(i + 1) % 5];
+        hOut[i] = hIn[i] - iv[(i + 1) % 5];
     }
 }
 

--- a/CLKeySearchDevice/clPollard.cl
+++ b/CLKeySearchDevice/clPollard.cl
@@ -55,7 +55,7 @@ void doRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5])
     };
 
     for(int i = 0; i < 5; i++) {
-        hOut[i] = endian(hIn[i] + iv[(i + 1) % 5]);
+        hOut[i] = hIn[i] + iv[(i + 1) % 5];
     }
 }
 

--- a/CLKeySearchDevice/keysearch.cl
+++ b/CLKeySearchDevice/keysearch.cl
@@ -87,7 +87,7 @@ void doRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5])
     };
 
     for(int i = 0; i < 5; i++) {
-        hOut[i] = endian(hIn[i] + iv[(i + 1) % 5]);
+        hOut[i] = hIn[i] + iv[(i + 1) % 5];
     }
 }
 

--- a/CudaKeySearchDevice/CudaHashLookup.cu
+++ b/CudaKeySearchDevice/CudaHashLookup.cu
@@ -24,24 +24,19 @@ __constant__ unsigned long long _BLOOM_FILTER_MASK64[1];
 __constant__ unsigned int _USE_BLOOM_FILTER[1];
 
 
-static unsigned int swp(unsigned int x)
-{
-	return (x << 24) | ((x << 8) & 0x00ff0000) | ((x >> 8) & 0x0000ff00) | (x >> 24);
-}
-
 static void undoRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5])
 {
-	unsigned int iv[5] = {
-		0x67452301,
-		0xefcdab89,
-		0x98badcfe,
-		0x10325476,
-		0xc3d2e1f0
-	};
+        unsigned int iv[5] = {
+                0x67452301,
+                0xefcdab89,
+                0x98badcfe,
+                0x10325476,
+                0xc3d2e1f0
+        };
 
-	for(int i = 0; i < 5; i++) {
-		hOut[i] = swp(hIn[i]) - iv[(i + 1) % 5];
-	}
+        for(int i = 0; i < 5; i++) {
+                hOut[i] = hIn[i] - iv[(i + 1) % 5];
+        }
 }
 
 /**

--- a/CudaKeySearchDevice/CudaKeySearchDevice.cpp
+++ b/CudaKeySearchDevice/CudaKeySearchDevice.cpp
@@ -299,14 +299,16 @@ bool CudaKeySearchDevice::verifyKey(const secp256k1::uint256 &privateKey, const 
     p.x.exportWords(xWords, 8, secp256k1::uint256::BigEndian);
     p.y.exportWords(yWords, 8, secp256k1::uint256::BigEndian);
 
-    unsigned int digest[5];
+    unsigned int be[5];
     if(compressed) {
-        Hash::hashPublicKeyCompressed(xWords, yWords, digest);
+        Hash::hashPublicKeyCompressed(xWords, yWords, be);
     } else {
-        Hash::hashPublicKey(xWords, yWords, digest);
+        Hash::hashPublicKey(xWords, yWords, be);
     }
 
-    for(int i = 0; i < 5; i++) {
+    unsigned int digest[5];
+    for(int i = 0; i < 5; ++i) {
+        digest[i] = util::endian(be[4 - i]);
         if(digest[i] != hash[i]) {
             return false;
         }

--- a/CudaKeySearchDevice/CudaKeySearchDevice.cu
+++ b/CudaKeySearchDevice/CudaKeySearchDevice.cu
@@ -35,7 +35,7 @@ static __device__ __forceinline__ void doRMD160FinalRound(const unsigned int hIn
     };
 
     for(int i = 0; i < 5; i++) {
-        hOut[i] = endian(hIn[i] + iv[(i + 1) % 5]);
+        hOut[i] = hIn[i] + iv[(i + 1) % 5];
     }
 }
 

--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -127,7 +127,7 @@ static __device__ __forceinline__ void doRMD160FinalRound(const unsigned int hIn
     };
 
     for(int i = 0; i < 5; i++) {
-        hOut[i] = endian(hIn[i] + iv[(i + 1) % 5]);
+        hOut[i] = hIn[i] + iv[(i + 1) % 5];
     }
 }
 

--- a/KeyFinder/PollardEngine.cpp
+++ b/KeyFinder/PollardEngine.cpp
@@ -59,7 +59,11 @@ void CPUPollardDevice::startTameWalk(const uint256 &start, uint64_t steps,
             if(checkPoint(p)) {
                 PollardMatch m;
                 m.scalar = k;
-                Hash::hashPublicKeyCompressed(p, m.hash);
+                unsigned int be[5];
+                Hash::hashPublicKeyCompressed(p, be);
+                for(int j = 0; j < 5; ++j) {
+                    m.hash[j] = util::endian(be[4 - j]);
+                }
                 _buffer.push(m);
             }
             k = k.add(1);
@@ -79,7 +83,11 @@ void CPUPollardDevice::startTameWalk(const uint256 &start, uint64_t steps,
         if(checkPoint(p)) {
             PollardMatch m;
             m.scalar = k;
-            Hash::hashPublicKeyCompressed(p, m.hash);
+            unsigned int be[5];
+            Hash::hashPublicKeyCompressed(p, be);
+            for(int j = 0; j < 5; ++j) {
+                m.hash[j] = util::endian(be[4 - j]);
+            }
             _buffer.push(m);
         }
     }
@@ -97,7 +105,11 @@ void CPUPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
             if(checkPoint(p)) {
                 PollardMatch m;
                 m.scalar = k;
-                Hash::hashPublicKeyCompressed(p, m.hash);
+                unsigned int be[5];
+                Hash::hashPublicKeyCompressed(p, be);
+                for(int j = 0; j < 5; ++j) {
+                    m.hash[j] = util::endian(be[4 - j]);
+                }
                 _buffer.push(m);
             }
             if(k.isZero()) {
@@ -122,7 +134,11 @@ void CPUPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
         if(checkPoint(p)) {
             PollardMatch m;
             m.scalar = kOffset;
-            Hash::hashPublicKeyCompressed(p, m.hash);
+            unsigned int be[5];
+            Hash::hashPublicKeyCompressed(p, be);
+            for(int j = 0; j < 5; ++j) {
+                m.hash[j] = util::endian(be[4 - j]);
+            }
             _buffer.push(m);
         }
     }
@@ -363,15 +379,19 @@ void PollardEngine::enumerateCandidate(const uint256 &priv, const ecpoint &pub) 
     // Compute the candidate's hash160 and ensure it matches one of the
     // supplied targets before invoking the callback.  This avoids reporting
     // non-matching candidates that may appear during the walk.
+    unsigned int be[5];
+    Hash::hashPublicKeyCompressed(pub, be);
     unsigned int digest[5];
-    Hash::hashPublicKeyCompressed(pub, digest);
+    for(int i = 0; i < 5; ++i) {
+        digest[i] = util::endian(be[4 - i]);
+    }
 
     if(_debug) {
         Logger::log(LogLevel::Debug,
                     "k=" + secp256k1::uint256(priv).toString(16) +
                     " Px=" + secp256k1::uint256(pub.x).toString(16) +
                     " Py=" + secp256k1::uint256(pub.y).toString(16) +
-                    " hash=" + hashToString(digest));
+                    " hash=" + hashToString(be));
     }
 
     bool match = false;

--- a/KeyFinder/PollardTypes.h
+++ b/KeyFinder/PollardTypes.h
@@ -2,6 +2,10 @@
 #define POLLARD_TYPES_H
 #include "secp256k1.h"
 
+// Hashes within the Pollard engine are stored in little-endian word order so
+// that bit offset 0 corresponds to the least significant bit of the RIPEMD160
+// digest.
+
 // Result produced by CPU fallback implementations where the entire
 // hash160 is returned for host-side window matching.  This remains for
 // backwards compatibility with the original PollardEngine walk code.
@@ -18,7 +22,8 @@ struct PollardMatch {
 // scalar.
 struct PollardWindow {
     unsigned int targetIdx;                  // index of the matching target
-    unsigned int offset;                     // bit offset within the hash160
+    unsigned int offset;                     // bit offset within the
+                                             // little-endian hash160
     unsigned int bits;                       // size of the window in bits
     secp256k1::uint256 scalarFragment;       // low ``offset+bits`` bits of k
 };

--- a/PollardTests/cuda_scalar_one.cu
+++ b/PollardTests/cuda_scalar_one.cu
@@ -13,7 +13,7 @@ __device__ static void doRMD160FinalRound(const unsigned int hIn[5], unsigned in
         0xc3d2e1f0
     };
     for(int i = 0; i < 5; i++) {
-        hOut[i] = endian(hIn[i] + iv[(i + 1) % 5]);
+        hOut[i] = hIn[i] + iv[(i + 1) % 5];
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ or `make cpu`. The feature is enabled with the following options:
 --debug               Log scalar, point coordinates, and hash for each attempt
 ```
 
+Target addresses are decoded to RIPEMD160 hashes in little-endian order.
+Bit offsets therefore start at the least significant bit of the digest.
+
 The union of all windows must cover 256 bits for a full reconstruction.
 Tame and wild walks run purely on the CPU and are currently best suited for
 small demonstrations or research.


### PR DESCRIPTION
## Summary
- Decode Base58 addresses to little-endian hash160 words so bit offsets map to the intended bits.
- Convert Pollard walk hashes and candidate verification to little-endian; drop byte swaps in GPU/OpenCL target loaders.
- Document that Pollard offsets start at the least significant bit of the little-endian hash160 value.

## Testing
- `make test CPU=1`

------
https://chatgpt.com/codex/tasks/task_e_68905237cdb4832e8e1d4181b63bc423