### PR TITLE
Cast stride to uint64_t for uint256 constructor in CUDA Pollard device

### DIFF
--- a/CudaKeySearchDevice/CudaPollardDevice.cpp
+++ b/CudaKeySearchDevice/CudaPollardDevice.cpp
@@ -181,7 +181,7 @@ void CudaPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
 
     uint256 base = start;
     unsigned long long stride = sequential ? static_cast<unsigned long long>(totalThreads) : 0ULL;
-    uint256 strideVal(stride);
+    uint256 strideVal(static_cast<uint64_t>(stride));
     uint256 startBase = base;
     if(sequential) {
         uint256 offset = multiplyModN(strideVal, uint256(steps - 1));


### PR DESCRIPTION
## Summary
- Explicitly cast stride to uint64_t when constructing strideVal in CudaPollardDevice.

## Testing
- `make -C CudaKeySearchDevice NVCC=nvcc NVCCFLAGS="" INCLUDE="" CUDA_INCLUDE="" CUDA_MATH="../cudaMath"` *(fails: `nvcc: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68905af22450832e8324b8751104b8ba