### PR TITLE
Compile generated cltest in unit tests

### DIFF
--- a/CLUnitTests/Makefile
+++ b/CLUnitTests/Makefile
@@ -1,15 +1,13 @@
 NAME=CLUnitTests
-CPPSRC:=$(wildcard *.cpp)
+CPPSRC:=main.cpp
 
 all:
 	cat ../clMath/secp256k1.cl secp256k1test.cl > cltest.cl
 	${BINDIR}/embedcl cltest.cl cltest.cpp _secp256k1_test_cl
-	${CXX} -o clunittest.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lclutil -lutil -lOpenCL
+	${CXX} -o clunittest.bin ${CPPSRC} cltest.cpp ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lclutil -lutil -lOpenCL
 	mkdir -p $(BINDIR)
 
 	cp clunittest.bin $(BINDIR)/clunittest
-
-
 
 clean:
 	rm -rf *.a *.o clunittest.bin cltest.cl cltest.cpp


### PR DESCRIPTION
## Summary
- ensure CLUnitTests builds generated cltest.cpp after embedding

## Testing
- `make BUILD_OPENCL=1` *(fails: CL/cl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68905d4067cc832e880b0afd5551046a