### PR TITLE
Link cudaMath constants into CudaKeySearchDevice

### DIFF
--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -19,12 +19,12 @@ cuda:
 
 ;for file in ${MATHSRC} ; do\
 ;   base=$(basename $$file); \
-;   ${NVCC} -c $$file -o $$base".o" ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
+;   ${NVCC} -c $$file -o ${CUDA_MATH}/$$base".o" ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
 ;done
 
-;${NVCC} ${NVCCFLAGS} -dlink -o cuda_libs.o *.o -lcudadevrt -lcudart
+;${NVCC} ${NVCCFLAGS} -dlink -o cuda_libs.o *.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o -lcudadevrt -lcudart
 
-;ar rvs ${LIBDIR}/lib$(NAME).a *.o
+;ar rvs ${LIBDIR}/lib$(NAME).a *.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o
 
 clean:
 ;rm -f *.o


### PR DESCRIPTION
## Summary
- include sha256 and ripemd160 constant objects from cudaMath when linking and archiving CudaKeySearchDevice
- build step now compiles these constants to the shared cudaMath directory before linking

## Testing
- `make clean` (pass)
- `make BUILD_CUDA=1` *(fails: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689060dd8268832ebbe79ead5ecfb515