### PR TITLE
Fix Pollard kernel outCount volatility

### DIFF
--- a/CLKeySearchDevice/clPollard.cl
+++ b/CLKeySearchDevice/clPollard.cl
@@ -99,7 +99,7 @@ Hash160 hashWindow(const unsigned int h[5], unsigned int offset, unsigned int bi
 }
 
 __kernel void pollard_walk(__global PollardWindow *out,
-                           __global uint *outCount,
+                           __global volatile uint *outCount,
                            uint maxOut,
                            __global ulong *seeds,
                            __global ulong *starts,


### PR DESCRIPTION
## Summary
- Mark `outCount` as a `volatile` global pointer in Pollard OpenCL kernel
- Preserve atomic output counting with `atomic_inc(outCount)`

## Testing
- `make BUILD_OPENCL=1 BUILD_CUDA=0` *(fails: `CL/cl.h` not found)*
- `apt-get install -y ocl-icd-opencl-dev` *(fails: package not found)*
- `./bin/clBitCrack --pollard` *(fails: binary not found due to build failure)*

------
https://chatgpt.com/codex/tasks/task_e_689063059c18832eaa69aea5bc386256