### PR TITLE
Fix math source object paths

### DIFF
--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -18,8 +18,8 @@ cuda:
 ;done
 
 ;for file in ${MATHSRC} ; do\
-;   base=$(basename $$file); \
-;   ${NVCC} -c $$file -o ${CUDA_MATH}/$$base".o" ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
+;   file_name=$${file##*/}; \
+;   ${NVCC} -c $$file -o ${CUDA_MATH}/$${file_name%.cu}.cu.o ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
 ;done
 
 ;${NVCC} ${NVCCFLAGS} -dlink -o cuda_libs.o *.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o -lcudadevrt -lcudart


### PR DESCRIPTION
## Summary
- Ensure CUDA math constant sources compile to object files in `cudaMath/` by removing directory components and properly naming outputs

## Testing
- `make` *(fails: /bin/sh: 2: -x: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890660f3e84832e9a55576c05da9712