### PR TITLE
Fix RMD160 final round constants

### DIFF
--- a/CLKeySearchDevice/CLKeySearchDevice.cpp
+++ b/CLKeySearchDevice/CLKeySearchDevice.cpp
@@ -36,7 +36,7 @@ static void undoRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5]
     };
 
     for(int i = 0; i < 5; i++) {
-        hOut[i] = hIn[i] - iv[(i + 1) % 5];
+        hOut[i] = hIn[i] - iv[i];
     }
 }
 

--- a/CLKeySearchDevice/clPollard.cl
+++ b/CLKeySearchDevice/clPollard.cl
@@ -55,7 +55,7 @@ void doRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5])
     };
 
     for(int i = 0; i < 5; i++) {
-        hOut[i] = hIn[i] + iv[(i + 1) % 5];
+        hOut[i] = hIn[i] + iv[i];
     }
 }
 

--- a/CLKeySearchDevice/keysearch.cl
+++ b/CLKeySearchDevice/keysearch.cl
@@ -87,7 +87,7 @@ void doRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5])
     };
 
     for(int i = 0; i < 5; i++) {
-        hOut[i] = hIn[i] + iv[(i + 1) % 5];
+        hOut[i] = hIn[i] + iv[i];
     }
 }
 

--- a/CudaKeySearchDevice/CudaHashLookup.cu
+++ b/CudaKeySearchDevice/CudaHashLookup.cu
@@ -35,7 +35,7 @@ static void undoRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5]
         };
 
         for(int i = 0; i < 5; i++) {
-                hOut[i] = hIn[i] - iv[(i + 1) % 5];
+                hOut[i] = hIn[i] - iv[i];
         }
 }
 

--- a/CudaKeySearchDevice/CudaKeySearchDevice.cu
+++ b/CudaKeySearchDevice/CudaKeySearchDevice.cu
@@ -35,7 +35,7 @@ static __device__ __forceinline__ void doRMD160FinalRound(const unsigned int hIn
     };
 
     for(int i = 0; i < 5; i++) {
-        hOut[i] = hIn[i] + iv[(i + 1) % 5];
+        hOut[i] = hIn[i] + iv[i];
     }
 }
 

--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -127,7 +127,7 @@ static __device__ __forceinline__ void doRMD160FinalRound(const unsigned int hIn
     };
 
     for(int i = 0; i < 5; i++) {
-        hOut[i] = hIn[i] + iv[(i + 1) % 5];
+        hOut[i] = hIn[i] + iv[i];
     }
 }
 

--- a/PollardTests/cuda_scalar_one.cu
+++ b/PollardTests/cuda_scalar_one.cu
@@ -13,7 +13,7 @@ __device__ static void doRMD160FinalRound(const unsigned int hIn[5], unsigned in
         0xc3d2e1f0
     };
     for(int i = 0; i < 5; i++) {
-        hOut[i] = hIn[i] + iv[(i + 1) % 5];
+        hOut[i] = hIn[i] + iv[i];
     }
 }
 


### PR DESCRIPTION
## Summary
- Correct RIPEMD160 final round by using matching IV word instead of rotated index in CUDA and OpenCL kernels
- Mirror the fix in host-side undo routines for hash lookup

## Testing
- `make BUILD_CUDA=1 BUILD_OPENCL=1 -j8` *(fails: cudaUtil.h:4:10: fatal error: cuda.h: No such file or directory)*
- `apt-get update` *(fails: 403 Forbidden - repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68906d631dc4832e9cd902d61f2d8a6c