### PR TITLE
Ensure pollard hash words are little-endian

### DIFF
--- a/CLKeySearchDevice/clPollard.cl
+++ b/CLKeySearchDevice/clPollard.cl
@@ -204,6 +204,9 @@ __kernel void pollard_walk(__global PollardWindow *out,
             uint finalHash[5];
             hashPublicKeyCompressed(px, py[7], digest);
             doRMD160FinalRound(digest, finalHash);
+            for(int j = 0; j < 5; j++) {
+                finalHash[j] = endian(finalHash[j]);
+            }
 
             for(uint w = 0; w < windowCount; w++) {
                 TargetWindow tw = windows[w];
@@ -243,6 +246,9 @@ __kernel void pollard_walk(__global PollardWindow *out,
             uint finalHash[5];
             hashPublicKeyCompressed(px, py[7], digest);
             doRMD160FinalRound(digest, finalHash);
+            for(int j = 0; j < 5; j++) {
+                finalHash[j] = endian(finalHash[j]);
+            }
 
             for(uint w = 0; w < windowCount; w++) {
                 TargetWindow tw = windows[w];

--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -3,6 +3,7 @@
 #include "sha256.cuh"   // SHA256 hashing for public keys
 #include "ripemd160.cuh" // RIPEMD160 finalisation
 #include "secp256k1.cuh" // EC point operations
+#include "ptx.cuh"       // byte order helpers
 
 __device__ void hashPublicKeyCompressed(const unsigned int*, unsigned int, unsigned int*);
 
@@ -357,6 +358,9 @@ extern "C" __global__ void pollardRandomWalk(CudaPollardMatch *out,
             // py[7] holds the least significant word; py[7] & 1 yields the parity bit
             hashPublicKeyCompressed(px, py[7] & 1, digest);
             doRMD160FinalRound(digest, finalHash);
+            for(int j = 0; j < 5; ++j) {
+                finalHash[j] = endian(finalHash[j]);
+            }
 
             unsigned int idx = atomicAdd(outCount, 1u);
             if(idx < maxOut) {
@@ -428,6 +432,9 @@ extern "C" __global__ void pollardWalk(GpuPollardWindow *out,
             unsigned int finalHash[5];
             hashPublicKeyCompressed(px, py[7] & 1, digest);
             doRMD160FinalRound(digest, finalHash);
+            for(int j = 0; j < 5; ++j) {
+                finalHash[j] = endian(finalHash[j]);
+            }
 
             for(unsigned int w = 0; w < windowCount; ++w) {
                 TargetWindow tw = windows[w];
@@ -467,6 +474,9 @@ extern "C" __global__ void pollardWalk(GpuPollardWindow *out,
             unsigned int finalHash[5];
             hashPublicKeyCompressed(px, py[7] & 1, digest);
             doRMD160FinalRound(digest, finalHash);
+            for(int j = 0; j < 5; ++j) {
+                finalHash[j] = endian(finalHash[j]);
+            }
 
             for(unsigned int w = 0; w < windowCount; ++w) {
                 TargetWindow tw = windows[w];


### PR DESCRIPTION
## Summary
- ensure CUDA pollard kernels swap RIPEMD160 digest words to little-endian before window matching or output
- mirror byte-order swap in OpenCL pollard kernel for consistent bit offsets

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68907b219a80832e9fdeca0c41d1aa06