### PR TITLE
Add hash160 CLI option

### DIFF
--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -631,7 +631,7 @@ bool parseShare(const std::string &s, uint32_t &idx, uint32_t &total)
     return true;
 }
 
-bool parseHash160(const std::string &s, unsigned int hash[5])
+bool parseHash160(const std::string &s, std::array<unsigned int,5> &hash)
 {
     if(s.length() != 40) {
         return false;
@@ -645,7 +645,7 @@ bool parseHash160(const std::string &s, unsigned int hash[5])
 
     for(int i = 0; i < 5; i++) {
         std::string word = s.substr((4 - i) * 8, 8);
-        unsigned int w;
+        unsigned int w = 0;
         std::stringstream ss;
         ss << std::hex << word;
         ss >> w;
@@ -820,13 +820,9 @@ int main(int argc, char **argv)
                 }
                 optShares = true;
             } else if(optArg.equals("", "--hash160")) {
-                unsigned int h[5];
-                if(!parseHash160(optArg.arg, h)) {
-                    throw std::string("invalid argument: expected 40 hex characters");
-                }
                 std::array<unsigned int,5> arr;
-                for(int j=0; j<5; j++) {
-                    arr[j] = h[j];
+                if(!parseHash160(optArg.arg, arr)) {
+                    throw std::string("invalid argument: expected 40 hex characters");
                 }
                 _config.hash160Targets.push_back(arr);
             } else if(optArg.equals("", "--stride")) {

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Options:
 --continue FILE
     Save/load progress from FILE
 
---hash160 HEX
-    Add a 40-hex-character RIPEMD160 hash as a search target
+  --hash160 <40-hex-chars>
+      Add a target specified as a 40-hex-character RIPEMD160 hash
 ```
 
 #### Examples


### PR DESCRIPTION
## Summary
- parse `--hash160` values into five little-endian 32-bit words using `std::array`
- push parsed hash160 entries directly into target list
- document `--hash160 <40-hex-chars>` usage in README

## Testing
- `make test CPU=1`

------
https://chatgpt.com/codex/tasks/task_e_6890809a3738832e851ca351231b8e3f