### PR TITLE
Resolve hashWindow symbol conflict in CUDA build

### DIFF
--- a/CudaKeySearchDevice/CudaHashLookup.cu
+++ b/CudaKeySearchDevice/CudaHashLookup.cu
@@ -27,7 +27,7 @@ struct Hash160 {
         unsigned int v[5];
 };
 
-__device__ Hash160 hashWindow(const unsigned int h[5], unsigned int offset, unsigned int bits)
+__device__ static Hash160 hashWindow(const unsigned int h[5], unsigned int offset, unsigned int bits)
 {
         Hash160 out;
         for(int i = 0; i < 5; ++i) {


### PR DESCRIPTION
## Summary
- give `hashWindow` in `CudaHashLookup.cu` internal linkage to avoid global name clash with `CudaPollard.cu`

## Testing
- `make dir_cudaKeySearchDevice` *(fails: cudaUtil.h:4:10: fatal error: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689088693174832e84e354abc43486af