### PR TITLE
Use word-wise scalar arithmetic in Pollard walk

### DIFF
--- a/CLKeySearchDevice/clPollard.cl
+++ b/CLKeySearchDevice/clPollard.cl
@@ -59,20 +59,26 @@ int ge256(const uint a[8], const uint b[8]) {
 }
 
 void sub256(const uint a[8], const uint b[8], uint r[8]) {
-    ulong borrow = 0UL;
+    uint borrow = 0U;
     for(int i=0;i<8;i++) {
-        ulong diff = (ulong)a[i] - b[i] - borrow;
-        r[i] = (uint)diff;
-        borrow = (diff >> 63) & 1UL;
+        uint ai = a[i];
+        uint bi = b[i];
+        uint t = ai - bi;
+        uint ri = t - borrow;
+        borrow = (ai < bi) | (t < borrow);
+        r[i] = ri;
     }
 }
 
 void addModN(const uint a[8], const uint b[8], uint r[8]) {
-    ulong carry = 0UL;
+    uint carry = 0U;
     for(int i=0;i<8;i++) {
-        ulong sum = (ulong)a[i] + b[i] + carry;
-        r[i] = (uint)sum;
-        carry = sum >> 32;
+        uint ai = a[i];
+        uint bi = b[i];
+        uint s = ai + bi;
+        uint ri = s + carry;
+        carry = (s < ai) | (ri < s);
+        r[i] = ri;
     }
     if(carry || ge256(r, ORDER)) {
         sub256(r, ORDER, r);

--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -72,20 +72,26 @@ __device__ static inline bool ge256(const unsigned int a[8], const unsigned int 
 }
 
 __device__ static inline void sub256(const unsigned int a[8], const unsigned int b[8], unsigned int r[8]) {
-    unsigned long long borrow = 0ULL;
+    unsigned int borrow = 0U;
     for(int i = 0; i < 8; ++i) {
-        unsigned long long diff = (unsigned long long)a[i] - b[i] - borrow;
-        r[i] = (unsigned int)diff;
-        borrow = (diff >> 63) & 1ULL;
+        unsigned int ai = a[i];
+        unsigned int bi = b[i];
+        unsigned int t = ai - bi;
+        unsigned int ri = t - borrow;
+        borrow = (ai < bi) | (t < borrow);
+        r[i] = ri;
     }
 }
 
 __device__ static inline void addModN(const unsigned int a[8], const unsigned int b[8], unsigned int r[8]) {
-    unsigned long long carry = 0ULL;
+    unsigned int carry = 0U;
     for(int i = 0; i < 8; ++i) {
-        unsigned long long sum = (unsigned long long)a[i] + b[i] + carry;
-        r[i] = (unsigned int)sum;
-        carry = sum >> 32;
+        unsigned int ai = a[i];
+        unsigned int bi = b[i];
+        unsigned int s = ai + bi;
+        unsigned int ri = s + carry;
+        carry = (s < ai) | (ri < s);
+        r[i] = ri;
     }
     if(carry || ge256(r, ORDER)) {
         sub256(r, ORDER, r);


### PR DESCRIPTION
## Summary
- Replace 64-bit temporary math in CudaPollard and clPollard with word-wise 32-bit operations for addition and subtraction.
- Preserve full 256-bit range when combining scalars in random walk.

## Testing
- `make test`
- Manual check adding 2 to 2^64-1 yields 2^64+1

------
https://chatgpt.com/codex/tasks/task_e_68908b761a5c832ea0d393be50294b48