### PR TITLE
Ensure consistent SM89 target for CUDA device linking

### DIFF
--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -22,7 +22,7 @@ cuda:
 ;   ${NVCC} -c $$file -o ${CUDA_MATH}/$${file_name%.cu}.cu.o ${NVCCFLAGS} ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
 ;done
 
-;${NVCC} -dlink ${NVCCFLAGS} -o cuda_libs.o *.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o -lcudadevrt -lcudart
+;${NVCC} -dlink ${NVCCFLAGS} -gencode=arch=compute_${COMPUTE_CAP},code=sm_${COMPUTE_CAP} -o cuda_libs.o *.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o -lcudadevrt -lcudart
 
 ;ar rvs ${LIBDIR}/lib$(NAME).a *.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o
 

--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -2,7 +2,8 @@ CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
 
 all:
 ifeq ($(BUILD_CUDA), 1)
-	${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
+	${NVCC} -dlink ${NVCCFLAGS} -o device_link.o ${LIBS} -L${CUDA_LIB} -lCudaKeySearchDevice -lcudautil -lcudadevrt -lcudart
+	${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} device_link.o ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
 	mkdir -p $(BINDIR)
 	cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif
@@ -21,3 +22,4 @@ clean:
 	rm -rf cuKeyFinder.bin
 	rm -rf clKeyFinder.bin
 	rm -rf KeyFinder.bin
+	rm -rf device_link.o


### PR DESCRIPTION
## Summary
- Target sm_89 explicitly during CUDA device linking in `CudaKeySearchDevice`.
- Introduce device-link stage in `KeyFinder` so host binary links CUDA objects for sm_89 as well.

## Testing
- `make BUILD_CUDA=1` *(fails: cuda.h: No such file or directory)*
- `bin/cuBitCrack` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689091457c9c832eb0dfc459c9603e82