### PR TITLE
Use uint256 big-endian import for Pollard hash windows

### DIFF
--- a/CLKeySearchDevice/CLPollardDevice.cpp
+++ b/CLKeySearchDevice/CLPollardDevice.cpp
@@ -8,10 +8,6 @@
 #include "clContext.h"
 #include "clutil.h"
 
-static inline unsigned int bswap32(unsigned int x) {
-    return (x << 24) | ((x << 8) & 0x00ff0000U) |
-           ((x >> 8) & 0x0000ff00U) | (x >> 24);
-}
 
 using namespace secp256k1;
 
@@ -23,10 +19,9 @@ CLPollardDevice::CLPollardDevice(PollardEngine &engine,
     : _engine(engine), _windowBits(windowBits), _offsets(offsets), _debug(debug) {
     _targets.reserve(targets.size());
     for(const auto &t : targets) {
+        uint256 v = uint256::importBigEndian(t.data(), 5);
         std::array<unsigned int,5> le;
-        for(int i = 0; i < 5; ++i) {
-            le[i] = bswap32(t[4 - i]);
-        }
+        v.exportWords(le.data(), 5);
         _targets.push_back(le);
     }
 }

--- a/CudaKeySearchDevice/CudaPollardDevice.cpp
+++ b/CudaKeySearchDevice/CudaPollardDevice.cpp
@@ -3,10 +3,6 @@
 #include <vector>
 #include <cstring>
 
-static inline unsigned int bswap32(unsigned int x) {
-    return (x << 24) | ((x << 8) & 0x00ff0000U) |
-           ((x >> 8) & 0x0000ff00U) | (x >> 24);
-}
 
 using namespace secp256k1;
 
@@ -71,10 +67,9 @@ CudaPollardDevice::CudaPollardDevice(PollardEngine &engine,
     : _engine(engine), _windowBits(windowBits), _offsets(offsets), _debug(debug) {
     _targets.reserve(targets.size());
     for(const auto &t : targets) {
+        uint256 v = uint256::importBigEndian(t.data(), 5);
         std::array<unsigned int,5> le;
-        for(int i = 0; i < 5; ++i) {
-            le[i] = bswap32(t[4 - i]);
-        }
+        v.exportWords(le.data(), 5);
         _targets.push_back(le);
     }
 }

--- a/PollardTests/main.cpp
+++ b/PollardTests/main.cpp
@@ -195,6 +195,21 @@ bool testHashWindowLEPython() {
     return got == expected;
 }
 
+bool testHashWindowLEK1() {
+    const unsigned int be[5] = {
+        0x751e76e8u,
+        0x199196d4u,
+        0x54941c45u,
+        0xd1b3a323u,
+        0xf1433bd6u
+    };
+    secp256k1::uint256 expected = secp256k1::uint256::importBigEndian(be, 5);
+    unsigned int le[5];
+    expected.exportWords(le, 5);
+    secp256k1::uint256 got = hashWindowLE(le, 0, 160);
+    return got == expected;
+}
+
 static bool runOpenCLScalarOne(unsigned int x[8], unsigned int y[8], unsigned int hash[5]) {
 #if BUILD_OPENCL
     try {
@@ -282,6 +297,7 @@ int main(){
     if(!testGlvMatchesClassic()) { std::cout<<"glv compare failed"<<std::endl; fails++; }
     if(!testDeterministicSeed()) { std::cout<<"deterministic seed failed"<<std::endl; fails++; }
     if(!testGpuScalarOne()) { std::cout<<"gpu scalar one failed"<<std::endl; fails++; }
+    if(!testHashWindowLEK1()) { std::cout<<"hash window k1 failed"<<std::endl; fails++; }
     if(!testHashWindowLEPython()) { std::cout<<"hash window python failed"<<std::endl; fails++; }
     if(fails==0) {
         std::cout<<"PASS"<<std::endl;

--- a/secp256k1lib/secp256k1.h
+++ b/secp256k1lib/secp256k1.h
@@ -144,18 +144,33 @@ namespace secp256k1 {
             return sub(x);
         }
 
-		void exportWords(unsigned int *buf, int len, int endian = LittleEndian) const
-		{
-			if(endian == LittleEndian) {
-				for(int i = 0; i < len; i++) {
-					buf[i] = v[i];
-				}
-			} else {
-				for(int i = 0; i < len; i++) {
-					buf[len - i - 1] = v[i];
-				}
-			}
-		}
+                void exportWords(unsigned int *buf, int len, int endian = LittleEndian) const
+                {
+                        if(endian == LittleEndian) {
+                                for(int i = 0; i < len; i++) {
+                                        buf[i] = v[i];
+                                }
+                        } else {
+                                for(int i = 0; i < len; i++) {
+                                        buf[len - i - 1] = v[i];
+                                }
+                        }
+                }
+
+                static uint256 importBigEndian(const unsigned int *src, int words)
+                {
+                        uint256 val;
+                        for(int i = 0; i < 8; i++) {
+                                val.v[i] = 0;
+                        }
+                        for(int i = 0; i < words && i < 8; i++) {
+                                unsigned int w = src[words - 1 - i];
+                                w = (w << 24) | ((w << 8) & 0x00ff0000U) |
+                                    ((w >> 8) & 0x0000ff00U) | (w >> 24);
+                                val.v[i] = w;
+                        }
+                        return val;
+                }
 
 		uint256 mul(const uint256 &val) const;
 


### PR DESCRIPTION
## Summary
- add `uint256::importBigEndian` helper
- replace manual bswap loops in CUDA and OpenCL Pollard devices
- unit test: ensure hashWindowLE of k=1 RIPEMD-160 matches expected

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6890978d6cb4832ea95b7672a3791627