### PR TITLE
Implement GLV scalar decomposition

### DIFF
--- a/PollardTests/main.cpp
+++ b/PollardTests/main.cpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <sstream>
 #include "AddressUtil.h"
-#include "../secp256k1lib/secp256k1_glv.h"
+#include "../secp256k1lib/secp256k1.h"
 
 #if BUILD_CUDA
 #include <cuda_runtime.h>


### PR DESCRIPTION
## Summary
- add GLV split and endomorphism helpers for secp256k1
- compute basepoint multiples with GLV on CUDA/OpenCL devices
- expose GLV scalar splitting in CPU secp256k1 library

## Testing
- `make test BUILD_CUDA=0 BUILD_OPENCL=0`
- `make dir_cudaKeySearchDevice BUILD_CUDA=1 BUILD_OPENCL=0` *(fails: cudaUtil.cpp:4:10: fatal error: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68909b9f7790832e9bf536e0c08830d2