### PR TITLE
Use namespaced clCall in Pollard device

### DIFF
--- a/CLKeySearchDevice/CLPollardDevice.cpp
+++ b/CLKeySearchDevice/CLPollardDevice.cpp
@@ -10,6 +10,7 @@
 
 
 using namespace secp256k1;
+using cl::clCall;
 
 CLPollardDevice::CLPollardDevice(PollardEngine &engine,
                                  unsigned int windowBits,


### PR DESCRIPTION
## Summary
- bring `cl::clCall` into scope in `CLPollardDevice.cpp`

## Testing
- `make BUILD_OPENCL=1` *(fails: CL/cl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6890a3390d6c832eb6c2a83792478be3