### PR TITLE
Expose PollardEngine hashWindow through public wrapper

### DIFF
--- a/KeyFinder/PollardEngine.cpp
+++ b/KeyFinder/PollardEngine.cpp
@@ -536,3 +536,8 @@ uint256 PollardEngine::hashWindow(const unsigned int h[5], unsigned int offset,
     return hashWindowLE(h, offset, bits);
 }
 
+uint256 PollardEngine::publicHashWindow(const unsigned int h[5], unsigned int offset,
+                                        unsigned int bits) {
+    return hashWindow(h, offset, bits);
+}
+

--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -85,6 +85,10 @@ public:
     // without a GPU.  Ownership of ``device`` is transferred to the engine.
     void setDevice(std::unique_ptr<PollardDevice> device);
 
+    // Public wrapper exposing the internal hashWindow helper
+    static secp256k1::uint256 publicHashWindow(const unsigned int h[5], unsigned int offset,
+                                               unsigned int bits);
+
 private:
     struct TargetState {
         std::array<unsigned int,5> hash;      // target RIPEMD160

--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -539,7 +539,7 @@ int runPollard()
     for(size_t t = 0; t < targetHashes.size(); ++t) {
         for(unsigned int off : offsets) {
             unsigned int bits = off + window;
-            secp256k1::uint256 rem = PollardEngine::hashWindow(targetHashes[t].data(), off, window);
+            secp256k1::uint256 rem = PollardEngine::publicHashWindow(targetHashes[t].data(), off, window);
             std::string modStr;
             if(bits >= 256) {
                 modStr = "2^256";


### PR DESCRIPTION
## Summary
- expose hash window helper via new `publicHashWindow` wrapper
- adjust main to use public wrapper for calculating hash remainders

## Testing
- `make -C KeyFinder CPU=1` *(fails: util.h missing)*
- `make -C PollardTests` *(fails: AddressUtil.h and secp256k1.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890a414c208832ea3e5e41cbd6d479e