### PR TITLE
Build CL unit tests with generated source

### DIFF
--- a/CLUnitTests/Makefile
+++ b/CLUnitTests/Makefile
@@ -1,13 +1,35 @@
+.RECIPEPREFIX := >
+
 NAME=CLUnitTests
 CPPSRC:=main.cpp
 
-all:
-	cat ../clMath/secp256k1.cl secp256k1test.cl > cltest.cl
-	${BINDIR}/embedcl cltest.cl cltest.cpp _secp256k1_test_cl
-	${CXX} -o clunittest.bin ${CPPSRC} cltest.cpp ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lclutil -lutil -lOpenCL
-	mkdir -p $(BINDIR)
+# Generated source from OpenCL kernels
+CLTEST:=cltest.cpp
 
-	cp clunittest.bin $(BINDIR)/clunittest
+# Object files to link into the final test binary
+OBJS:=$(CPPSRC:.cpp=.o) $(CLTEST:.cpp=.o)
+
+all: $(NAME)
+
+# Combine the OpenCL source files
+cltest.cl: ../clMath/secp256k1.cl secp256k1test.cl
+>cat $^ > $@
+
+# Embed the combined OpenCL source into a C++ file
+$(CLTEST): cltest.cl
+>${BINDIR}/embedcl $< $@ _secp256k1_test_cl
+
+# Compile C++ sources
+%.o: %.cpp
+>${CXX} -c $< ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS}
+
+# Link objects into the unit test executable
+$(NAME): $(OBJS)
+>${CXX} -o clunittest.bin $(OBJS) ${LIBS} -L${OPENCL_LIB} -lclutil -lutil -lOpenCL
+>mkdir -p $(BINDIR)
+>cp clunittest.bin $(BINDIR)/clunittest
 
 clean:
-	rm -rf *.a *.o clunittest.bin cltest.cl cltest.cpp
+>rm -rf *.a *.o clunittest.bin cltest.cl cltest.cpp
+
+.PHONY: all clean $(NAME)


### PR DESCRIPTION
## Summary
- Refactor CLUnitTests Makefile to generate and compile OpenCL test code separately before linking into `clunittest`

## Testing
- `make dir_clunittest` *(fails: CL/cl.h missing; OpenCL headers unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6890a4ed8088832e85788d4cf6b60f56