### PR TITLE
Remove explicit CUDA device linking in KeyFinder

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -2,10 +2,9 @@ CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
 
 all:
 ifeq ($(BUILD_CUDA), 1)
-	${NVCC} -dlink ${NVCCFLAGS} -o device_link.o ${LIBS} -L${CUDA_LIB} -lCudaKeySearchDevice -lcudautil -lcudadevrt -lcudart
-	${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} device_link.o ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
-	mkdir -p $(BINDIR)
-	cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
+        ${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
+        mkdir -p $(BINDIR)
+        cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif
 ifeq ($(BUILD_OPENCL),1)
 	${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
@@ -19,7 +18,6 @@ ifeq ($(CPU),1)
 endif
 
 clean:
-	rm -rf cuKeyFinder.bin
-	rm -rf clKeyFinder.bin
-	rm -rf KeyFinder.bin
-	rm -rf device_link.o
+        rm -rf cuKeyFinder.bin
+        rm -rf clKeyFinder.bin
+        rm -rf KeyFinder.bin


### PR DESCRIPTION
## Summary
- simplify KeyFinder CUDA build by letting nvcc handle device linking directly
- drop unused device_link.o artifact and corresponding clean step

## Testing
- `make BUILD_CUDA=1 dir_keyfinder` *(fails: cudaUtil.h:4:10: fatal error: cuda.h: No such file or directory)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890aacc4984832e91a7ca99132f6aa2