### PR TITLE
Align hash endianness across devices

### DIFF
--- a/CLKeySearchDevice/CLPollardDevice.cpp
+++ b/CLKeySearchDevice/CLPollardDevice.cpp
@@ -18,15 +18,8 @@ CLPollardDevice::CLPollardDevice(PollardEngine &engine,
                                  const std::vector<unsigned int> &offsets,
                                  const std::vector<std::array<unsigned int,5>> &targets,
                                  bool debug)
-    : _engine(engine), _windowBits(windowBits), _offsets(offsets), _debug(debug) {
-    _targets.reserve(targets.size());
-    for(const auto &t : targets) {
-        uint256 v = uint256::importBigEndian(t.data(), 5);
-        std::array<unsigned int,5> le;
-        v.exportWords(le.data(), 5);
-        _targets.push_back(le);
-    }
-}
+    : _engine(engine), _windowBits(windowBits), _offsets(offsets),
+      _targets(targets), _debug(debug) {}
 
 uint256 CLPollardDevice::maskBits(unsigned int bits) {
     uint256 m(0);
@@ -36,6 +29,9 @@ uint256 CLPollardDevice::maskBits(unsigned int bits) {
     return m;
 }
 
+// Extract ``bits`` bits starting at ``offset`` from the 160-bit hash ``h``.
+// The input hash is expected in little-endian word order to match the
+// representation used throughout the engine and GPU kernels.
 uint256 CLPollardDevice::hashWindowLE(const uint32_t h[5], uint32_t offset, uint32_t bits) {
     uint256 out(0);
     uint32_t word  = offset / 32;

--- a/CLKeySearchDevice/CLPollardDevice.h
+++ b/CLKeySearchDevice/CLPollardDevice.h
@@ -9,12 +9,15 @@ class CLPollardDevice : public PollardDevice {
     PollardEngine &_engine;
     unsigned int _windowBits;
     std::vector<unsigned int> _offsets;
+    // RIPEMD160 hashes in little-endian word order
     std::vector<std::array<unsigned int,5>> _targets;
     bool _debug;
 public:
     CLPollardDevice(PollardEngine &engine,
                     unsigned int windowBits,
                     const std::vector<unsigned int> &offsets,
+                    // ``targets`` must contain RIPEMD160 hashes in
+                    // little-endian word order
                     const std::vector<std::array<unsigned int,5>> &targets,
                     bool debug);
 

--- a/CudaKeySearchDevice/CudaPollardDevice.cpp
+++ b/CudaKeySearchDevice/CudaPollardDevice.cpp
@@ -20,6 +20,9 @@ struct GpuTargetWindow {
     unsigned int target[5];
 };
 
+// Extract ``bits`` bits starting at ``offset`` from the 160-bit hash ``h``.
+// ``h`` must be provided in little-endian word order so bit offsets match
+// the expectations of the device kernels.
 static uint256 hashWindowLE(const unsigned int h[5], unsigned int offset, unsigned int bits) {
     uint256 out(0);
     unsigned int word = offset / 32;
@@ -64,15 +67,8 @@ CudaPollardDevice::CudaPollardDevice(PollardEngine &engine,
                                      const std::vector<unsigned int> &offsets,
                                      const std::vector<std::array<unsigned int,5>> &targets,
                                      bool debug)
-    : _engine(engine), _windowBits(windowBits), _offsets(offsets), _debug(debug) {
-    _targets.reserve(targets.size());
-    for(const auto &t : targets) {
-        uint256 v = uint256::importBigEndian(t.data(), 5);
-        std::array<unsigned int,5> le;
-        v.exportWords(le.data(), 5);
-        _targets.push_back(le);
-    }
-}
+    : _engine(engine), _windowBits(windowBits), _offsets(offsets),
+      _targets(targets), _debug(debug) {}
 
 void CudaPollardDevice::startTameWalk(const uint256 &start, uint64_t steps,
                                       const uint256 &seed, bool sequential) {

--- a/CudaKeySearchDevice/CudaPollardDevice.h
+++ b/CudaKeySearchDevice/CudaPollardDevice.h
@@ -9,12 +9,15 @@ class CudaPollardDevice : public PollardDevice {
     PollardEngine &_engine;
     unsigned int _windowBits;
     std::vector<unsigned int> _offsets;
+    // RIPEMD160 hashes in little-endian word order
     std::vector<std::array<unsigned int,5>> _targets;
     bool _debug;
 public:
     CudaPollardDevice(PollardEngine &engine,
                       unsigned int windowBits,
                       const std::vector<unsigned int> &offsets,
+                      // ``targets`` must contain RIPEMD160 hashes in
+                      // little-endian word order
                       const std::vector<std::array<unsigned int,5>> &targets,
                       bool debug);
 

--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -41,9 +41,9 @@ public:
      * @param windowBits  Size of each bit window collected from a walk.
      * @param offsets     Bit offsets (within the hash) describing where each
      *                    window is collected.
-     * @param targets     RIPEMD160 hashes that the walk is attempting to
-     *                    recover.  Each target maintains its own set of
-     *                    constraints.
+     * @param targets     RIPEMD160 hashes (five 32-bit words, little-endian)
+     *                    that the walk is attempting to recover.  Each
+     *                    target maintains its own set of constraints.
      */
     PollardEngine(ResultCallback cb,
                   unsigned int windowBits,
@@ -85,13 +85,14 @@ public:
     // without a GPU.  Ownership of ``device`` is transferred to the engine.
     void setDevice(std::unique_ptr<PollardDevice> device);
 
-    // Public wrapper exposing the internal hashWindow helper
+    // Public wrapper exposing the internal hashWindow helper.  ``h`` must be
+    // supplied in little-endian word order.
     static secp256k1::uint256 publicHashWindow(const unsigned int h[5], unsigned int offset,
                                                unsigned int bits);
 
 private:
     struct TargetState {
-        std::array<unsigned int,5> hash;      // target RIPEMD160
+        std::array<unsigned int,5> hash;      // target RIPEMD160 (little-endian)
         std::vector<Constraint> constraints;  // gathered constraints
         std::set<unsigned int> seenOffsets;   // offsets already collected
     };


### PR DESCRIPTION
## Summary
- remove big-endian conversions from CUDA and OpenCL Pollard devices and treat hashes as little-endian
- document that hash windows and device targets use little-endian word order

## Testing
- `make test BUILD_CUDA=0 BUILD_OPENCL=0`

------
https://chatgpt.com/codex/tasks/task_e_6890b1cd2fc4832ead89f65f3aeb2476