### PR TITLE
Implement GLV helpers and apply endomorphism

### DIFF
--- a/PollardTests/main.cpp
+++ b/PollardTests/main.cpp
@@ -47,7 +47,16 @@ static secp256k1::ecpoint scalarMultiplyBase(uint64_t k) {
     secp256k1::uint256 scalar(k);
     auto split = secp256k1::splitScalar(scalar);
     secp256k1::ecpoint p1 = secp256k1::multiplyPoint(split.k1, secp256k1::G());
+    if(split.k1Neg) {
+        p1.y = secp256k1::negModP(p1.y);
+    }
+    if(split.k2.isZero()) {
+        return p1;
+    }
     secp256k1::ecpoint p2 = secp256k1::multiplyPoint(split.k2, secp256k1::glvEndomorphismBasePoint());
+    if(split.k2Neg) {
+        p2.y = secp256k1::negModP(p2.y);
+    }
     return secp256k1::addPoints(p1, p2);
 }
 

--- a/secp256k1lib/secp256k1.h
+++ b/secp256k1lib/secp256k1.h
@@ -350,6 +350,9 @@ namespace secp256k1 {
         const uint256 BETA(_BETA_WORDS);
         const uint256 LAMBDA(_LAMBDA_WORDS);
 
+        inline const uint256& glvLambda() { return LAMBDA; }
+        inline const uint256& glvBeta() { return BETA; }
+
         ecpoint pointAtInfinity();
         ecpoint G();
         uint256 multiplyModP(const uint256 &a, const uint256&b);
@@ -364,7 +367,7 @@ namespace secp256k1 {
 
         inline ecpoint glvEndomorphismBasePoint()
         {
-            uint256 x = multiplyModP(G().x, BETA);
+            uint256 x = multiplyModP(G().x, glvBeta());
             return ecpoint(x, G().y);
         }
 


### PR DESCRIPTION
## Summary
- expose `glvLambda`/`glvBeta` helpers and use them in the endomorphism base point calculation
- handle sign and zero cases when performing GLV-split scalar base multiplications on CPU
- extend CUDA test harness with GLV-based base-point multiplication helpers

## Testing
- `make test`
- `BUILD_CUDA=1 make test` *(fails: /usr/local/cuda-12.8/bin/nvcc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890b7046f94832e9ac7abc8fedd1d8c