### PR TITLE
Document 256-bit scalar handling in Pollard kernels

### DIFF
--- a/CLKeySearchDevice/CLPollardDevice.cpp
+++ b/CLKeySearchDevice/CLPollardDevice.cpp
@@ -67,6 +67,7 @@ struct PollardWindowCL {
     cl_uint targetIdx;
     cl_uint offset;
     cl_uint bits;
+    // 256-bit scalar fragment returned by the device
     cl_uint k[8];
 };
 

--- a/CLKeySearchDevice/clPollard.cl
+++ b/CLKeySearchDevice/clPollard.cl
@@ -8,6 +8,7 @@ typedef struct {
     uint targetIdx;
     uint offset;
     uint bits;
+    // 256-bit scalar for this step (little-endian words)
     uint k[8];
 } PollardWindow;
 

--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -12,6 +12,7 @@ struct GpuPollardWindow {
     unsigned int targetIdx;
     unsigned int offset;
     unsigned int bits;
+    // Full 256-bit scalar of the distinguished point in little-endian word order
     unsigned int k[8];
 };
 

--- a/CudaKeySearchDevice/CudaPollardDevice.cpp
+++ b/CudaKeySearchDevice/CudaPollardDevice.cpp
@@ -10,6 +10,7 @@ struct GpuPollardWindow {
     unsigned int targetIdx;
     unsigned int offset;
     unsigned int bits;
+    // Returned scalar fragment (full 256-bit value in little-endian order)
     unsigned int k[8];
 };
 


### PR DESCRIPTION
## Summary
- Clarify that CUDA GpuPollardWindow now stores the entire 256-bit scalar in little-endian words.
- Note full scalar fragments returned from CUDA host/device interface and OpenCL counterparts.

## Testing
- `make test CPU=1`


------
https://chatgpt.com/codex/tasks/task_e_6890dcd21a48832e8ae10c3f8bf3ed6e