### PR TITLE
Use 160-bit hash window type

### DIFF
--- a/CLKeySearchDevice/clPollard.cl
+++ b/CLKeySearchDevice/clPollard.cl
@@ -419,9 +419,8 @@ void hashPublicKeyCompressed(const unsigned int x[8], unsigned int yParity, unsi
 }
 
 // Extract ``bits`` bits starting at ``offset`` from the 160-bit RIPEMD160
-// digest ``h``. Bits are interpreted in little-endian order and returned as a
-// 160-bit value with higher bits cleared.  The result is stored as five
-// 32-bit little-endian words.
+// digest ``h``. Bits are interpreted in little-endian order and the result is
+// returned as five 32-bit words with higher bits cleared.
 typedef struct { uint v[5]; } Hash160;
 
 Hash160 hashWindow(const uint h[5], uint offset, uint bits)
@@ -430,8 +429,7 @@ Hash160 hashWindow(const uint h[5], uint offset, uint bits)
     for(int i=0;i<5;i++) out.v[i]=0u;
     unsigned int word = offset / 32;
     unsigned int bit  = offset % 32;
-    unsigned int span = bit + bits;
-    unsigned int words = (span + 31) / 32;
+    unsigned int words = (bits + 31) / 32;
     for(unsigned int i=0;i<words && word + i < 5; i++) {
         ulong val = ((ulong)h[word + i]) >> bit;
         if(bit && word + i + 1 < 5) {
@@ -439,8 +437,9 @@ Hash160 hashWindow(const uint h[5], uint offset, uint bits)
         }
         out.v[i] = (uint)(val & 0xffffffffUL);
     }
-    if(span % 32) {
-        uint mask = (1u << (span % 32)) - 1u;
+    uint maskBits = bits % 32;
+    if(maskBits) {
+        uint mask = (1u << maskBits) - 1u;
         out.v[words-1] &= mask;
     }
     for(unsigned int i=words;i<5;i++) {

--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -86,9 +86,11 @@ public:
     void setDevice(std::unique_ptr<PollardDevice> device);
 
     // Public wrapper exposing the internal hashWindow helper.  ``h`` must be
-    // supplied in little-endian word order.
-    static secp256k1::uint256 publicHashWindow(const unsigned int h[5], unsigned int offset,
-                                               unsigned int bits);
+    // supplied in little-endian word order.  The returned array contains the
+    // extracted window as five 32-bit words with unused high words set to
+    // zero.
+    static std::array<unsigned int,5> publicHashWindow(const unsigned int h[5], unsigned int offset,
+                                                       unsigned int bits);
 
 private:
     struct TargetState {
@@ -127,8 +129,8 @@ private:
     void handleMatch(const PollardMatch &m);
     void pollDevice();
 
-    static secp256k1::uint256 hashWindow(const unsigned int h[5], unsigned int offset,
-                                         unsigned int bits);
+    static std::array<unsigned int,5> hashWindow(const unsigned int h[5], unsigned int offset,
+                                                 unsigned int bits);
 };
 
 #endif

--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -539,7 +539,10 @@ int runPollard()
     for(size_t t = 0; t < targetHashes.size(); ++t) {
         for(unsigned int off : offsets) {
             unsigned int bits = off + window;
-            secp256k1::uint256 rem = PollardEngine::publicHashWindow(targetHashes[t].data(), off, window);
+            auto remWords = PollardEngine::publicHashWindow(targetHashes[t].data(), off, window);
+            secp256k1::uint256 rem;
+            for(int i = 0; i < 5; ++i) rem.v[i] = remWords[i];
+            for(int i = 5; i < 8; ++i) rem.v[i] = 0u;
             std::string modStr;
             if(bits >= 256) {
                 modStr = "2^256";


### PR DESCRIPTION
## Summary
- Switch hashWindow/hashWindowLE helpers to return a dedicated 160-bit type and standardize little‑endian handling across CPU, CUDA and OpenCL implementations
- Update PollardEngine and tooling to consume the new 160-bit results
- Extend unit tests with high-offset and cross-word window cases

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6890e7499348832e8dc97da3389fe104