### PR TITLE
Implement GLV scalar decomposition for base multiplication

### DIFF
--- a/CLKeySearchDevice/clPollard.cl
+++ b/CLKeySearchDevice/clPollard.cl
@@ -385,17 +385,12 @@ void scalarMultiplyBase(const __private uint *k, __private uint *rx, __private u
         copyBigInt(r1y, ry);
         return;
     }
-    uint base2x[8];
-    uint base2y[8];
-    uint gx[8];
-    uint beta[8];
-    copyBigIntConst(_GX, gx);
-    copyBigIntConst(_BETA, beta);
-    mulModP(gx, beta, base2x);
-    copyBigIntConst(_GY, base2y);
     uint r2x[8];
     uint r2y[8];
-    scalarMultiplySmall(base2x, base2y, s.k2, r2x, r2y);
+    scalarMultiplySmall(base1x, base1y, s.k2, r2x, r2y);
+    uint beta[8];
+    copyBigIntConst(_BETA, beta);
+    mulModP(r2x, beta, r2x);
     if(s.k2Neg) {
         uint ny[8];
         negModP(r2y, ny);

--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -291,13 +291,10 @@ __device__ static void scalarMultiplyBase(const unsigned int k[8], unsigned int 
         return;
     }
 
-    unsigned int base2x[8];
-    unsigned int base2y[8];
-    mulModP(_GX, _BETA, base2x);
-    copyBigInt(_GY, base2y);
     unsigned int r2x[8];
     unsigned int r2y[8];
-    scalarMultiplySmall(base2x, base2y, split.k2, r2x, r2y);
+    scalarMultiplySmall(_GX, _GY, split.k2, r2x, r2y);
+    mulModP(r2x, _BETA, r2x);
     if(split.k2Neg) {
         unsigned int ny[8];
         negModP(r2y, ny);

--- a/PollardTests/cuda_scalar_one.cu
+++ b/PollardTests/cuda_scalar_one.cu
@@ -195,14 +195,10 @@ __device__ static void scalarMultiplyBase(unsigned long long k, unsigned int rx[
         return;
     }
 
-    unsigned int base2x[8];
-    unsigned int base2y[8];
-    mulModP(_GX, _BETA, base2x);
-    copyBigInt(_GY, base2y);
-
     unsigned int r2x[8];
     unsigned int r2y[8];
-    scalarMultiplySmall(base2x, base2y, split.k2, r2x, r2y);
+    scalarMultiplySmall(_GX, _GY, split.k2, r2x, r2y);
+    mulModP(r2x, _BETA, r2x);
     if(split.k2Neg) {
         unsigned int ny[8];
         negModP(r2y, ny);

--- a/PollardTests/main.cpp
+++ b/PollardTests/main.cpp
@@ -46,18 +46,12 @@ static inline uint64_t xorshift128plus(RNGState &st)
 static secp256k1::ecpoint scalarMultiplyBase(uint64_t k) {
     secp256k1::uint256 scalar(k);
     auto split = secp256k1::splitScalar(scalar);
-    secp256k1::ecpoint p1 = secp256k1::multiplyPoint(split.k1, secp256k1::G());
-    if(split.k1Neg) {
-        p1.y = secp256k1::negModP(p1.y);
+    secp256k1::ecpoint p1 = secp256k1::multiplyPointSmall(split.k1, secp256k1::G());
+    secp256k1::ecpoint p2 = secp256k1::multiplyPointSmall(split.k2, secp256k1::G());
+    if(!split.k2.isZero()) {
+        p2 = secp256k1::glvEndomorphism(p2);
     }
-    if(split.k2.isZero()) {
-        return p1;
-    }
-    secp256k1::ecpoint p2 = secp256k1::multiplyPoint(split.k2, secp256k1::glvEndomorphismBasePoint());
-    if(split.k2Neg) {
-        p2.y = secp256k1::negModP(p2.y);
-    }
-    return secp256k1::addPoints(p1, p2);
+    return secp256k1::glvRecombine(split, p1, p2);
 }
 
 static inline uint64_t next_random_step(RNGState &st)

--- a/secp256k1lib/secp256k1.cpp
+++ b/secp256k1lib/secp256k1.cpp
@@ -731,6 +731,24 @@ ecpoint secp256k1::multiplyPoint(const uint256 &k, const ecpoint &p)
 	return sum;
 }
 
+ecpoint secp256k1::multiplyPointSmall(const uint256 &k, const ecpoint &p)
+{
+        ecpoint sum = pointAtInfinity();
+        ecpoint d = p;
+
+        for(int i = 0; i < 128; i++) {
+                unsigned int mask = 1 << (i % 32);
+
+                if(k.v[i / 32] & mask) {
+                        sum = addPoints(sum, d);
+                }
+
+                d = doublePoint(d);
+        }
+
+        return sum;
+}
+
 uint256 generatePrivateKey()
 {
 	uint256 k;

--- a/secp256k1lib/secp256k1.h
+++ b/secp256k1lib/secp256k1.h
@@ -460,6 +460,7 @@ namespace secp256k1 {
             return r;
         }
 
+
         uint256 negModP(const uint256 &x);
 	uint256 negModN(const uint256 &x);
 
@@ -473,8 +474,27 @@ namespace secp256k1 {
 
 	uint256 invModP(const uint256 &x);
 
-	bool isPointAtInfinity(const ecpoint &p);
-	ecpoint multiplyPoint(const uint256 &k, const ecpoint &p);
+        bool isPointAtInfinity(const ecpoint &p);
+        ecpoint multiplyPoint(const uint256 &k, const ecpoint &p);
+        ecpoint multiplyPointSmall(const uint256 &k, const ecpoint &p);
+
+        inline ecpoint glvEndomorphism(const ecpoint &p)
+        {
+            return ecpoint(multiplyModP(p.x, glvBeta()), p.y);
+        }
+
+        inline ecpoint glvRecombine(const GLVSplit &s, const ecpoint &p1, const ecpoint &p2)
+        {
+            ecpoint r1 = p1;
+            ecpoint r2 = p2;
+            if(s.k1Neg) {
+                r1.y = negModP(r1.y);
+            }
+            if(s.k2Neg) {
+                r2.y = negModP(r2.y);
+            }
+            return addPoints(r1, r2);
+        }
 
 	uint256 addModN(const uint256 &a, const uint256 &b);
 	uint256 subModN(const uint256 &a, const uint256 &b);


### PR DESCRIPTION
## Summary
- add 128-bit multiply helper and GLV recombine/endormorphism functions to secp256k1 library
- apply GLV split/endormorphism to CUDA and OpenCL `scalarMultiplyBase`
- use GLV-based base multiplication in CPU tests

## Testing
- `make test CPU=1`

------
https://chatgpt.com/codex/tasks/task_e_68910d201bac832e80d65be9b0556e2b