### PR TITLE
Use GLV endomorphism for base point multiplication

### DIFF
--- a/CLKeySearchDevice/clPollard.cl
+++ b/CLKeySearchDevice/clPollard.cl
@@ -385,12 +385,16 @@ void scalarMultiplyBase(const __private uint *k, __private uint *rx, __private u
         copyBigInt(r1y, ry);
         return;
     }
-    uint r2x[8];
-    uint r2y[8];
-    scalarMultiplySmall(base1x, base1y, s.k2, r2x, r2y);
+    uint base2x[8];
+    uint base2y[8];
+    copyBigIntConst(_GX, base2x);
+    copyBigIntConst(_GY, base2y);
     uint beta[8];
     copyBigIntConst(_BETA, beta);
-    mulModP(r2x, beta, r2x);
+    mulModP(base2x, beta, base2x);
+    uint r2x[8];
+    uint r2y[8];
+    scalarMultiplySmall(base2x, base2y, s.k2, r2x, r2y);
     if(s.k2Neg) {
         uint ny[8];
         negModP(r2y, ny);

--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -292,10 +292,15 @@ __device__ static void scalarMultiplyBase(const unsigned int k[8], unsigned int 
         return;
     }
 
+    unsigned int base2x[8];
+    unsigned int base2y[8];
+    copyBigInt(_GX, base2x);
+    copyBigInt(_GY, base2y);
+    mulModP(base2x, _BETA, base2x);
+
     unsigned int r2x[8];
     unsigned int r2y[8];
-    scalarMultiplySmall(_GX, _GY, split.k2, r2x, r2y);
-    mulModP(r2x, _BETA, r2x);
+    scalarMultiplySmall(base2x, base2y, split.k2, r2x, r2y);
     if(split.k2Neg) {
         unsigned int ny[8];
         negModP(r2y, ny);

--- a/PollardTests/cuda_scalar_one.cu
+++ b/PollardTests/cuda_scalar_one.cu
@@ -195,10 +195,15 @@ __device__ static void scalarMultiplyBase(unsigned long long k, unsigned int rx[
         return;
     }
 
+    unsigned int base2x[8];
+    unsigned int base2y[8];
+    copyBigInt(_GX, base2x);
+    copyBigInt(_GY, base2y);
+    mulModP(base2x, _BETA, base2x);
+
     unsigned int r2x[8];
     unsigned int r2y[8];
-    scalarMultiplySmall(_GX, _GY, split.k2, r2x, r2y);
-    mulModP(r2x, _BETA, r2x);
+    scalarMultiplySmall(base2x, base2y, split.k2, r2x, r2y);
     if(split.k2Neg) {
         unsigned int ny[8];
         negModP(r2y, ny);

--- a/PollardTests/main.cpp
+++ b/PollardTests/main.cpp
@@ -46,11 +46,9 @@ static inline uint64_t xorshift128plus(RNGState &st)
 static secp256k1::ecpoint scalarMultiplyBase(uint64_t k) {
     secp256k1::uint256 scalar(k);
     auto split = secp256k1::splitScalar(scalar);
+    secp256k1::ecpoint base2 = secp256k1::glvEndomorphismBasePoint();
     secp256k1::ecpoint p1 = secp256k1::multiplyPointSmall(split.k1, secp256k1::G());
-    secp256k1::ecpoint p2 = secp256k1::multiplyPointSmall(split.k2, secp256k1::G());
-    if(!split.k2.isZero()) {
-        p2 = secp256k1::glvEndomorphism(p2);
-    }
+    secp256k1::ecpoint p2 = secp256k1::multiplyPointSmall(split.k2, base2);
     return secp256k1::glvRecombine(split, p1, p2);
 }
 

--- a/secp256k1lib/secp256k1_glv.h
+++ b/secp256k1lib/secp256k1_glv.h
@@ -13,6 +13,47 @@ struct GLVSplit {
     GLVSplit() : k1(0), k2(0), k1Neg(false), k2Neg(false) {}
 };
 
+/* Lambda value such that (lambda * G.x, G.y) = lambda * G */
+static inline const uint256 &glvLambda()
+{
+    static const unsigned int LAMBDA_WORDS[8] = {
+        0x5363AD4Cu, 0xC05C30E0u, 0xA5261C02u, 0x8812645Au,
+        0x122E22EAu, 0x20816678u, 0xDF02967Cu, 0x1B23BD72u
+    };
+    static const uint256 LAMBDA(LAMBDA_WORDS);
+    return LAMBDA;
+}
+
+/* Beta constant for the x-coordinate endomorphism */
+static inline const uint256 &glvBeta()
+{
+    static const unsigned int BETA_WORDS[8] = {
+        0x7AE96A2Bu, 0x657C0710u, 0x6E64479Eu, 0xAC3434E9u,
+        0x9CF04975u, 0x12F58995u, 0xC1396C28u, 0x719501EEu
+    };
+    static const uint256 BETA(BETA_WORDS);
+    return BETA;
+}
+
+static inline ecpoint glvEndomorphism(const ecpoint &p)
+{
+    uint256 x = multiplyModP(p.x, glvBeta());
+    return ecpoint(x, p.y);
+}
+
+static inline ecpoint glvRecombine(const GLVSplit &s, const ecpoint &p1, const ecpoint &p2)
+{
+    ecpoint r1 = p1;
+    ecpoint r2 = p2;
+    if(s.k1Neg) {
+        r1.y = negModP(r1.y);
+    }
+    if(s.k2Neg) {
+        r2.y = negModP(r2.y);
+    }
+    return addPoints(r1, r2);
+}
+
 /*
  * Split a scalar ``k`` into ``k1`` and ``k2`` using the efficiently
  * computable endomorphism on secp256k1.  The result satisfies


### PR DESCRIPTION
## Summary
- add GLV constants and helper routines in secp256k1lib
- apply scalar splitting and endomorphism in CPU and GPU base multipliers

## Testing
- `make BUILD_CUDA=1 test` *(fails: /usr/local/cuda-12.8/bin/nvcc: not found)*
- `make test`
- `/tmp/bench`

------
https://chatgpt.com/codex/tasks/task_e_68912c5b00dc832e8f312e3dd3fe46bf