### PR TITLE
Mark digest arrays as private

### DIFF
--- a/CLKeySearchDevice/keysearch.cl
+++ b/CLKeySearchDevice/keysearch.cl
@@ -164,7 +164,7 @@ __kernel void multiplyStepKernel(
 }
 
 
-void hashPublicKey(uint256_t x, uint256_t y, unsigned int* digestOut)
+void hashPublicKey(uint256_t x, uint256_t y, __private unsigned int* digestOut)
 {
     unsigned int hash[8];
 
@@ -178,7 +178,7 @@ void hashPublicKey(uint256_t x, uint256_t y, unsigned int* digestOut)
     ripemd160sha256NoFinal(hash, digestOut);
 }
 
-void hashPublicKeyCompressed(uint256_t x, unsigned int yParity, unsigned int* digestOut)
+void hashPublicKeyCompressed(uint256_t x, unsigned int yParity, __private unsigned int* digestOut)
 {
     unsigned int hash[8];
 

--- a/clMath/ripemd160.cl
+++ b/clMath/ripemd160.cl
@@ -288,7 +288,7 @@ void ripemd160sha256(const unsigned int x[8], unsigned int digest[5])
 }
 
 
-void ripemd160sha256NoFinal(const unsigned int x[8], unsigned int digest[5])
+void ripemd160sha256NoFinal(const unsigned int x[8], __private unsigned int digest[5])
 {
     unsigned int a1 = _RIPEMD160_IV[0];
     unsigned int b1 = _RIPEMD160_IV[1];


### PR DESCRIPTION
## Summary
- ensure RIPEMD-160 helper uses a private digest buffer
- update OpenCL key search hashing helpers to use private digest pointers

## Testing
- `make BUILD_OPENCL=1` *(fails: CL/cl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891389de31c832eadc015266e7eab1b