### PR TITLE
Fix window hashing for device Pollard implementations

### DIFF
--- a/CLKeySearchDevice/CLPollardDevice.cpp
+++ b/CLKeySearchDevice/CLPollardDevice.cpp
@@ -36,8 +36,7 @@ uint256 CLPollardDevice::hashWindowLE(const uint32_t h[5], uint32_t offset, uint
     uint256 out(0);
     uint32_t word  = offset / 32;
     uint32_t bit   = offset % 32;
-    uint32_t span  = bit + bits;
-    uint32_t words = (span + 31) / 32;
+    uint32_t words = (bits + 31) / 32;
     for(uint32_t i = 0; i < words && word + i < 5; ++i) {
         uint64_t val = ((uint64_t)h[word + i]) >> bit;
         if(bit && word + i + 1 < 5) {
@@ -45,8 +44,9 @@ uint256 CLPollardDevice::hashWindowLE(const uint32_t h[5], uint32_t offset, uint
         }
         out.v[i] = static_cast<uint32_t>(val & 0xffffffffULL);
     }
-    if(span % 32) {
-        uint32_t mask = (1u << (span % 32)) - 1u;
+    uint32_t maskBits = bits % 32;
+    if(maskBits) {
+        uint32_t mask = (1u << maskBits) - 1u;
         out.v[words - 1] &= mask;
     }
     for(uint32_t i = words; i < 8; ++i) {

--- a/CudaKeySearchDevice/CudaPollardDevice.cpp
+++ b/CudaKeySearchDevice/CudaPollardDevice.cpp
@@ -29,8 +29,7 @@ static uint256 hashWindowLE(const uint32_t h[5], uint32_t offset, uint32_t bits)
     uint256 out(0);
     uint32_t word = offset / 32;
     uint32_t bit = offset % 32;
-    uint32_t span = bit + bits;
-    uint32_t words = (span + 31) / 32;
+    uint32_t words = (bits + 31) / 32;
     for(uint32_t i = 0; i < words && word + i < 5; ++i) {
         uint64_t val = ((uint64_t)h[word + i]) >> bit;
         if(bit && word + i + 1 < 5) {
@@ -38,8 +37,9 @@ static uint256 hashWindowLE(const uint32_t h[5], uint32_t offset, uint32_t bits)
         }
         out.v[i] = static_cast<uint32_t>(val & 0xffffffffULL);
     }
-    if(span % 32) {
-        uint32_t mask = (1u << (span % 32)) - 1u;
+    uint32_t maskBits = bits % 32;
+    if(maskBits) {
+        uint32_t mask = (1u << maskBits) - 1u;
         out.v[words - 1] &= mask;
     }
     for(uint32_t i = words; i < 8; ++i) {


### PR DESCRIPTION
## Summary
- Align device-side hashWindowLE with kernel logic
- Ensure window hashes use exact bit count and mask final word

## Testing
- `make CPU=1 test`
- `g++ -std=c++11 -Isecp256k1lib -IKeyFinder -IKeyFinderLib -ICudaKeySearchDevice -Iutil -IAddressUtil -ICmdParse -ICryptoUtil -ILogger -c CudaKeySearchDevice/CudaPollardDevice.cpp` *(fails: cuda_runtime.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68914be7cf58832e81a3583f9554013f