### PR TITLE
Write results to default file

### DIFF
--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -99,35 +99,35 @@ void resultCallback(KeySearchResult info)
 {
         _resultFound = true;
 
-        if(_config.resultsFile.length() != 0) {
-                Logger::log(LogLevel::Info, "Found key for address '" + info.address + "'. Written to '" + _config.resultsFile + "'");
+        std::string outFile = _config.resultsFile.length() != 0 ? _config.resultsFile : "found.txt";
 
-                std::string s = info.address + " " + info.privateKey.toString(16) + " " + info.publicKey.toString(info.compressed);
-                util::appendToFile(_config.resultsFile, s);
+        Logger::log(LogLevel::Info, "Found key for address '" + info.address + "'. Written to '" + outFile + "'");
 
-                return;
+        std::string s = info.address + " " + info.privateKey.toString(16) + " " + info.publicKey.toString(info.compressed);
+        util::appendToFile(outFile, s);
+
+        if(_config.resultsFile.length() == 0) {
+                std::string logStr = "Address:     " + info.address + "\n";
+                logStr += "Private key: " + info.privateKey.toString(16) + "\n";
+                logStr += "Compressed:  ";
+
+                if(info.compressed) {
+                        logStr += "yes\n";
+                } else {
+                        logStr += "no\n";
+                }
+
+                logStr += "Public key:  \n";
+
+                if(info.compressed) {
+                        logStr += info.publicKey.toString(true) + "\n";
+                } else {
+                        logStr += info.publicKey.x.toString(16) + "\n";
+                        logStr += info.publicKey.y.toString(16) + "\n";
+                }
+
+                Logger::log(LogLevel::Info, logStr);
         }
-
-	std::string logStr = "Address:     " + info.address + "\n";
-	logStr += "Private key: " + info.privateKey.toString(16) + "\n";
-	logStr += "Compressed:  ";
-
-	if(info.compressed) {
-		logStr += "yes\n";
-	} else {
-		logStr += "no\n";
-	}
-
-	logStr += "Public key:  \n";
-
-	if(info.compressed) {
-		logStr += info.publicKey.toString(true) + "\n";
-	} else {
-		logStr += info.publicKey.x.toString(16) + "\n";
-		logStr += info.publicKey.y.toString(16) + "\n";
-	}
-
-	Logger::log(LogLevel::Info, logStr);
 }
 
 /**
@@ -229,7 +229,7 @@ void usage()
     printf("-t, --threads N         N threads per block\n");
     printf("-p, --points N          N points per thread\n");
     printf("-i, --in FILE           Read addresses from FILE, one per line\n");
-    printf("-o, --out FILE          Write keys to FILE\n");
+    printf("-o, --out FILE          Write keys to FILE (default: found.txt)\n");
     printf("-f, --follow            Follow text output\n");
     printf("--list-devices          List available devices\n");
     printf("--keyspace KEYSPACE     Specify the keyspace:\n");

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Options:
     Read addresses from FILE, one address per line. If FILE is "-" then stdin is read
 
 -o, --out FILE
-    Append private keys to FILE, one per line
+    Append private keys to FILE, one per line (default: found.txt). Use this option to override the default output file
 
 -d, --device N
     Use device with ID equal to N


### PR DESCRIPTION
## Summary
- Append found keys to a default `found.txt` when no output file is specified
- Clarify default results file in CLI usage and README

## Testing
- `make test CPU=1`

------
https://chatgpt.com/codex/tasks/task_e_6891582b564c832ea921b21edfa2c49f