### PR TITLE
Gracefully join Pool workers in CRT tool

### DIFF
--- a/tools/pollard_kangaroo_crt.py
+++ b/tools/pollard_kangaroo_crt.py
@@ -264,7 +264,9 @@ def main():
                         if args.verbose:
                             print(f"[MAIN] collected off={off} -> {lo}")
                 if len(constraints) == len(offsets):
-                    pool.terminate()
+                    # Wait for workers to exit to avoid orphaned GPU tasks
+                    pool.close()
+                    pool.join()
                     break
 
         if len(constraints) < len(offsets):


### PR DESCRIPTION
## Summary
- Close and join multiprocessing pool once all constraints are collected to prevent orphaned GPU tasks

## Testing
- `python -m py_compile tools/pollard_kangaroo_crt.py`
- `pip install ecdsa` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python tools/pollard_kangaroo_crt.py --help` *(fails: ModuleNotFoundError: No module named 'ecdsa')*

------
https://chatgpt.com/codex/tasks/task_e_68916455400c832ea73cb75e48231b3b