### PR TITLE
Refactor hash160 parsing and add tests

### DIFF
--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -666,16 +666,20 @@ bool parseHash160(const std::string &s, std::array<unsigned int,5> &hash)
         }
     }
 
-    for(int i = 0; i < 5; i++) {
-        std::string word = s.substr((4 - i) * 8, 8);
-        unsigned int w = 0;
+    std::array<unsigned char,20> bytes;
+    for(int i = 0; i < 20; ++i) {
+        unsigned int b = 0;
         std::stringstream ss;
-        ss << std::hex << word;
-        ss >> w;
-        hash[i] = ((w & 0x000000ffU) << 24) |
-                  ((w & 0x0000ff00U) << 8)  |
-                  ((w & 0x00ff0000U) >> 8)  |
-                  ((w & 0xff000000U) >> 24);
+        ss << std::hex << s.substr(i * 2, 2);
+        ss >> b;
+        bytes[i] = static_cast<unsigned char>(b);
+    }
+
+    for(int i = 0; i < 5; ++i) {
+        hash[i] = static_cast<unsigned int>(bytes[i * 4]) |
+                  (static_cast<unsigned int>(bytes[i * 4 + 1]) << 8) |
+                  (static_cast<unsigned int>(bytes[i * 4 + 2]) << 16) |
+                  (static_cast<unsigned int>(bytes[i * 4 + 3]) << 24);
     }
 
     return true;


### PR DESCRIPTION
## Summary
- Rewrote `parseHash160` to perform byte-level decoding and little-endian word composition
- Added shared `parseHash160` helper and unit test validating `hashWindowLE` window offsets

## Testing
- `make test BUILD_CUDA=0 BUILD_OPENCL=0`
- `./bin/pollardtests`

------
https://chatgpt.com/codex/tasks/task_e_68916f555970832eae7b16ed6f6512e0