### PR TITLE
test: validate device hash windows

### DIFF
--- a/CLKeySearchDevice/CLPollardDevice.cpp
+++ b/CLKeySearchDevice/CLPollardDevice.cpp
@@ -284,7 +284,11 @@ void CLPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
 extern "C" bool runCLHashWindowLE(const unsigned int h[5], unsigned int offset,
                                    unsigned int bits, unsigned int out[5]) {
     // Lightweight wrapper used by unit tests to validate the OpenCL window
-    // extraction logic.
+    // extraction logic.  Guard against invalid ranges so tests can detect
+    // misuse.
+    if(offset + bits > 160u) {
+        return false;
+    }
     uint256 v = CLPollardDevice::hashWindowLE(h, offset, bits);
     v.exportWords(out, 5);
     return true;

--- a/CudaKeySearchDevice/CudaPollardDevice.cpp
+++ b/CudaKeySearchDevice/CudaPollardDevice.cpp
@@ -307,7 +307,11 @@ void CudaPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
 extern "C" bool runCudaHashWindowLE(const unsigned int h[5], unsigned int offset,
                                     unsigned int bits, unsigned int out[5]) {
     // Lightweight wrapper used by unit tests to validate the CUDA window
-    // extraction logic.
+    // extraction logic.  Guard against invalid ranges so tests can detect
+    // misuse.
+    if(offset + bits > 160u) {
+        return false;
+    }
     uint256 v = hashWindowLE(h, offset, bits);
     v.exportWords(out, 5);
     return true;

--- a/PollardTests/main.cpp
+++ b/PollardTests/main.cpp
@@ -513,17 +513,9 @@ bool testDeviceHashWindowLE() {
     unsigned int le[5];
     secp256k1::uint256::importBigEndian(be, 5).exportWords(le, 5);
 
-    std::vector<unsigned int> offsets = {0u, 20u, 40u, 60u, 80u, 120u};
-    std::vector<unsigned int> sizes   = {8u, 20u, 32u, 40u, 80u};
-
     bool ran = false;
-    bool pass = true;
-
-    for(unsigned int off : offsets) {
-        for(unsigned int bits : sizes) {
-            if(off + bits > 160u) {
-                continue;
-            }
+    for(unsigned int off = 0; off < 160u; ++off) {
+        for(unsigned int bits = 1; bits <= 160u - off; ++bits) {
             auto ref = hashWindowLE(le, off, bits);
 #if BUILD_CUDA
             unsigned int outCuda[5];
@@ -531,8 +523,7 @@ bool testDeviceHashWindowLE() {
                 ran = true;
                 for(int i = 0; i < 5; ++i) {
                     if(outCuda[i] != ref[i]) {
-                        pass = false;
-                        break;
+                        return false;
                     }
                 }
             }
@@ -543,24 +534,19 @@ bool testDeviceHashWindowLE() {
                 ran = true;
                 for(int i = 0; i < 5; ++i) {
                     if(outCl[i] != ref[i]) {
-                        pass = false;
-                        break;
+                        return false;
                     }
                 }
             }
 #endif
-            if(!pass) {
-                return false;
-            }
         }
     }
 
     if(!ran) {
         std::cout << "device hashWindowLE test skipped" << std::endl;
-        return true;
     }
 
-    return pass;
+    return true;
 }
 
 int main(){


### PR DESCRIPTION
## Summary
- expose guard wrappers around CUDA/OpenCL hashWindowLE helpers
- validate device hashWindowLE output against CPU helper for every offset/size

## Testing
- `make test CPU=1`

------
https://chatgpt.com/codex/tasks/task_e_68919891b82c832e8e97907324e0a6ff