### PR TITLE
Add pollard tests build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,10 +139,12 @@ dir_clunittest: dir_clutil
 dir_pollardtests: dir_secp256k1lib dir_cryptoutil dir_util dir_addressutil dir_logger
 	make --directory PollardTests
 
+pollard-tests: dir_pollardtests
+
 test: dir_pollardtests
 	$(BINDIR)/pollardtests
 
-.PHONY: cpu
+.PHONY: cpu pollard-tests
 cpu:
 	$(MAKE) CPU=1 all
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ Build CPU-only Pollard/CRT components:
 make CPU=1
 ```
 
+Build the Pollard test executable:
+```
+make pollard-tests
+```
+This builds `bin/pollardtests`.
+
 ### Python Pollard Rho/Kangaroo utility
 
 A prototype implementation of a dynamic bit-window Pollard Rho variant with tame and wild kangaroos and a CRT-based reconstruction is available in `tools/pollard_kangaroo_crt.py`.


### PR DESCRIPTION
## Summary
- Add `pollard-tests` phony target to build Pollard test executable
- Document how to build Pollard tests in README

## Testing
- `make pollard-tests`


------
https://chatgpt.com/codex/tasks/task_e_689199d37f64832ea379ee377178879c