### PR TITLE
Ensure worker pool terminates and restarts

### DIFF
--- a/tools/pollard_kangaroo_crt.py
+++ b/tools/pollard_kangaroo_crt.py
@@ -198,7 +198,7 @@ def run_round(args, L, U, ws, offsets, mask, max_steps, n, n_tame, n_wild,
                 if len(constraints) == len(offsets):
                     break
         finally:
-            pool.close()
+            pool.terminate()
             pool.join()
 
         if len(constraints) < len(offsets):
@@ -306,10 +306,11 @@ def main():
             if run_round(args, L, U, ws, offsets, mask, max_steps, n,
                          n_tame, n_wild, target, chunk):
                 break
-            if not args.full:
-                print("no key found")
-                break
-            print("no key found, relaunching walks...")
+            if args.full:
+                print("no key found, relaunching walks...")
+                continue
+            print("no key found")
+            break
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
## Summary
- Terminate the multiprocessing pool and wait on all workers to ensure CUDA processes exit cleanly.
- Refine the `--full` mode loop to relaunch searches until the key is found or interrupted.

## Testing
- `python3 -m py_compile tools/pollard_kangaroo_crt.py`
- `python3 tools/pollard_kangaroo_crt.py --help` *(fails: No module named 'ecdsa')*
- `pip install ecdsa` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891a85f8b5c832e87b8aa769fb9ea9b