### PR TITLE
Simplify public key hashing

### DIFF
--- a/AddressUtil/hash.cpp
+++ b/AddressUtil/hash.cpp
@@ -89,136 +89,185 @@ void Hash::hashPublicKeyCompressed(const secp256k1::ecpoint &p, unsigned int *di
 
 void Hash::hashPublicKey(const unsigned int *x, const unsigned int *y, unsigned int *digest)
 {
-	unsigned int msg[16];
+	unsigned char pub[65];
+
+	// Build uncompressed public key bytes: 0x04 || x || y
+	pub[0] = 0x04;
+	for(int i = 0; i < 8; ++i) {
+		pub[1 + i * 4] = (unsigned char)(x[i] >> 24);
+		pub[2 + i * 4] = (unsigned char)(x[i] >> 16);
+		pub[3 + i * 4] = (unsigned char)(x[i] >> 8);
+		pub[4 + i * 4] = (unsigned char)(x[i]);
+	}
+	for(int i = 0; i < 8; ++i) {
+		pub[33 + i * 4] = (unsigned char)(y[i] >> 24);
+		pub[34 + i * 4] = (unsigned char)(y[i] >> 16);
+		pub[35 + i * 4] = (unsigned char)(y[i] >> 8);
+		pub[36 + i * 4] = (unsigned char)(y[i]);
+	}
+
 	unsigned int sha256Digest[8];
+	unsigned int msg[16];
+	unsigned char block[64];
 
-	// 0x04 || x || y
-	msg[15] = (y[7] >> 8) | (y[6] << 24);
-	msg[14] = (y[6] >> 8) | (y[5] << 24);
-	msg[13] = (y[5] >> 8) | (y[4] << 24);
-	msg[12] = (y[4] >> 8) | (y[3] << 24);
-	msg[11] = (y[3] >> 8) | (y[2] << 24);
-	msg[10] = (y[2] >> 8) | (y[1] << 24);
-	msg[9] = (y[1] >> 8) | (y[0] << 24);
-	msg[8] = (y[0] >> 8) | (x[7] << 24);
-	msg[7] = (x[7] >> 8) | (x[6] << 24);
-	msg[6] = (x[6] >> 8) | (x[5] << 24);
-	msg[5] = (x[5] >> 8) | (x[4] << 24);
-	msg[4] = (x[4] >> 8) | (x[3] << 24);
-	msg[3] = (x[3] >> 8) | (x[2] << 24);
-	msg[2] = (x[2] >> 8) | (x[1] << 24);
-	msg[1] = (x[1] >> 8) | (x[0] << 24);
-	msg[0] = (x[0] >> 8) | 0x04000000;
-
+	// First 64 bytes
+	memcpy(block, pub, 64);
+	for(int i = 0; i < 16; ++i) {
+		msg[i] = ((unsigned int)block[i * 4] << 24) |
+			 ((unsigned int)block[i * 4 + 1] << 16) |
+			 ((unsigned int)block[i * 4 + 2] << 8) |
+			 (unsigned int)block[i * 4 + 3];
+	}
 
 	crypto::sha256Init(sha256Digest);
 	crypto::sha256(msg, sha256Digest);
 
-	// Zero out the message
-	for(int i = 0; i < 16; i++) {
-		msg[i] = 0;
+	// Second block: remaining byte, padding and length
+	memset(block, 0, sizeof(block));
+	block[0] = pub[64];
+	block[1] = 0x80;
+	unsigned long long bitLen = 65ULL * 8ULL;
+	for(int i = 0; i < 8; ++i) {
+		block[56 + i] = (unsigned char)(bitLen >> (56 - 8 * i));
 	}
-
-	// Set first byte, padding, and length
-	msg[0] = (y[7] << 24) | 0x00800000;
-	msg[15] = 65 * 8;
-
+	for(int i = 0; i < 16; ++i) {
+		msg[i] = ((unsigned int)block[i * 4] << 24) |
+			 ((unsigned int)block[i * 4 + 1] << 16) |
+			 ((unsigned int)block[i * 4 + 2] << 8) |
+			 (unsigned int)block[i * 4 + 3];
+	}
 	crypto::sha256(msg, sha256Digest);
 
-	for(int i = 0; i < 16; i++) {
-		msg[i] = 0;
+	// Convert SHA-256 digest to bytes
+	unsigned char shaBytes[32];
+	for(int i = 0; i < 8; ++i) {
+		shaBytes[i * 4] = (unsigned char)(sha256Digest[i] >> 24);
+		shaBytes[i * 4 + 1] = (unsigned char)(sha256Digest[i] >> 16);
+		shaBytes[i * 4 + 2] = (unsigned char)(sha256Digest[i] >> 8);
+		shaBytes[i * 4 + 3] = (unsigned char)(sha256Digest[i]);
 	}
 
-	// Swap to little-endian
-	for(int i = 0; i < 8; i++) {
-		msg[i] = endian(sha256Digest[i]);
+	// Prepare RIPEMD160 block
+	memset(block, 0, sizeof(block));
+	memcpy(block, shaBytes, 32);
+	block[32] = 0x80;
+	unsigned long long rmdLen = 32ULL * 8ULL;
+	block[56] = (unsigned char)(rmdLen & 0xff);
+	block[57] = (unsigned char)((rmdLen >> 8) & 0xff);
+	block[58] = (unsigned char)((rmdLen >> 16) & 0xff);
+	block[59] = (unsigned char)((rmdLen >> 24) & 0xff);
+	for(int i = 0; i < 16; ++i) {
+		msg[i] = ((unsigned int)block[i * 4]) |
+			 ((unsigned int)block[i * 4 + 1] << 8) |
+			 ((unsigned int)block[i * 4 + 2] << 16) |
+			 ((unsigned int)block[i * 4 + 3] << 24);
 	}
 
-	// Message length, little endian
-	msg[8] = 0x00000080;
-	msg[14] = 256;
-	msg[15] = 0;
+	unsigned int rmdDigest[5];
+	crypto::ripemd160(msg, rmdDigest);
 
-	crypto::ripemd160(msg, digest);
+	for(int i = 0; i < 5; ++i) {
+		digest[i] = rmdDigest[i];
+	}
 }
 
 
 
 void Hash::hashPublicKeyCompressed(const unsigned int *x, const unsigned int *y, unsigned int *digest)
 {
-	unsigned int msg[16] = { 0 };
+	unsigned char pub[33];
+
+	pub[0] = (y[7] & 0x01) ? 0x03 : 0x02;
+	for(int i = 0; i < 8; ++i) {
+		pub[1 + i * 4] = (unsigned char)(x[i] >> 24);
+		pub[2 + i * 4] = (unsigned char)(x[i] >> 16);
+		pub[3 + i * 4] = (unsigned char)(x[i] >> 8);
+		pub[4 + i * 4] = (unsigned char)(x[i]);
+	}
+
 	unsigned int sha256Digest[8];
+	unsigned int msg[16];
+	unsigned char block[64] = {0};
 
-	// Compressed public key format
-	msg[15] = 33 * 8;
-
-	msg[8] = (x[7] << 24) | 0x00800000;
-	msg[7] = (x[7] >> 8) | (x[6] << 24);
-	msg[6] = (x[6] >> 8) | (x[5] << 24);
-	msg[5] = (x[5] >> 8) | (x[4] << 24);
-	msg[4] = (x[4] >> 8) | (x[3] << 24);
-	msg[3] = (x[3] >> 8) | (x[2] << 24);
-	msg[2] = (x[2] >> 8) | (x[1] << 24);
-	msg[1] = (x[1] >> 8) | (x[0] << 24);
-
-	if(y[7] & 0x01) {
-		msg[0] = (x[0] >> 8) | 0x03000000;
-	} else {
-		msg[0] = (x[0] >> 8) | 0x02000000;
+	memcpy(block, pub, 33);
+	block[33] = 0x80;
+	unsigned long long bitLen = 33ULL * 8ULL;
+	for(int i = 0; i < 8; ++i) {
+		block[56 + i] = (unsigned char)(bitLen >> (56 - 8 * i));
+	}
+	for(int i = 0; i < 16; ++i) {
+		msg[i] = ((unsigned int)block[i * 4] << 24) |
+			 ((unsigned int)block[i * 4 + 1] << 16) |
+			 ((unsigned int)block[i * 4 + 2] << 8) |
+			 (unsigned int)block[i * 4 + 3];
 	}
 
 	crypto::sha256Init(sha256Digest);
 	crypto::sha256(msg, sha256Digest);
 
-	for(int i = 0; i < 16; i++) {
-		msg[i] = 0;
+	unsigned char shaBytes[32];
+	for(int i = 0; i < 8; ++i) {
+		shaBytes[i * 4] = (unsigned char)(sha256Digest[i] >> 24);
+		shaBytes[i * 4 + 1] = (unsigned char)(sha256Digest[i] >> 16);
+		shaBytes[i * 4 + 2] = (unsigned char)(sha256Digest[i] >> 8);
+		shaBytes[i * 4 + 3] = (unsigned char)(sha256Digest[i]);
 	}
 
-	// Swap to little-endian
-	for(int i = 0; i < 8; i++) {
-		msg[i] = endian(sha256Digest[i]);
+	memset(block, 0, sizeof(block));
+	memcpy(block, shaBytes, 32);
+	block[32] = 0x80;
+	unsigned long long rmdLen = 32ULL * 8ULL;
+	block[56] = (unsigned char)(rmdLen & 0xff);
+	block[57] = (unsigned char)((rmdLen >> 8) & 0xff);
+	block[58] = (unsigned char)((rmdLen >> 16) & 0xff);
+	block[59] = (unsigned char)((rmdLen >> 24) & 0xff);
+	for(int i = 0; i < 16; ++i) {
+		msg[i] = ((unsigned int)block[i * 4]) |
+			 ((unsigned int)block[i * 4 + 1] << 8) |
+			 ((unsigned int)block[i * 4 + 2] << 16) |
+			 ((unsigned int)block[i * 4 + 3] << 24);
 	}
 
-	// Message length, little endian
-	msg[8] = 0x00000080;
-	msg[14] = 256;
-	msg[15] = 0;
+	unsigned int rmdDigest[5];
+	crypto::ripemd160(msg, rmdDigest);
 
-        crypto::ripemd160(msg, digest);
+	for(int i = 0; i < 5; ++i) {
+		digest[i] = rmdDigest[i];
+	}
 }
 
 void Hash::hashPublicKeyCompressed(const unsigned char *key, unsigned int *digest)
 {
-        unsigned int msg[16] = {0};
-        unsigned int sha256Digest[8];
+	unsigned int msg[16] = {0};
+	unsigned int sha256Digest[8];
 
-        // Copy 33-byte compressed key into message buffer for SHA-256
-        for(int i = 0; i < 8; ++i) {
-                msg[i] = ((unsigned int)key[i * 4] << 24) |
-                         ((unsigned int)key[i * 4 + 1] << 16) |
-                         ((unsigned int)key[i * 4 + 2] << 8) |
-                         (unsigned int)key[i * 4 + 3];
-        }
+	// Copy 33-byte compressed key into message buffer for SHA-256
+	for(int i = 0; i < 8; ++i) {
+		msg[i] = ((unsigned int)key[i * 4] << 24) |
+			 ((unsigned int)key[i * 4 + 1] << 16) |
+			 ((unsigned int)key[i * 4 + 2] << 8) |
+			 (unsigned int)key[i * 4 + 3];
+	}
 
-        // Last byte followed by padding and message length
-        msg[8] = ((unsigned int)key[32] << 24) | 0x00800000;
-        msg[15] = 33 * 8;
+	// Last byte followed by padding and message length
+	msg[8] = ((unsigned int)key[32] << 24) | 0x00800000;
+	msg[15] = 33 * 8;
 
-        crypto::sha256Init(sha256Digest);
-        crypto::sha256(msg, sha256Digest);
+	crypto::sha256Init(sha256Digest);
+	crypto::sha256(msg, sha256Digest);
 
-        // Prepare RIPEMD160 input
-        for(int i = 0; i < 16; ++i) {
-                msg[i] = 0;
-        }
+	// Prepare RIPEMD160 input
+	for(int i = 0; i < 16; ++i) {
+		msg[i] = 0;
+	}
 
-        for(int i = 0; i < 8; ++i) {
-                msg[i] = endian(sha256Digest[i]);
-        }
+	for(int i = 0; i < 8; ++i) {
+		msg[i] = endian(sha256Digest[i]);
+	}
 
-        msg[8] = 0x00000080;
-        msg[14] = 256;
-        msg[15] = 0;
+	msg[8] = 0x00000080;
+	msg[14] = 256;
+	msg[15] = 0;
 
-        crypto::ripemd160(msg, digest);
+	crypto::ripemd160(msg, digest);
 }


### PR DESCRIPTION
## Summary
- rewrite Hash::hashPublicKey and hashPublicKeyCompressed to assemble big-endian byte arrays and hash them via sha256 and ripemd160
- return final hash as little-endian digest words while keeping the public API unchanged

## Testing
- `make dir_addressutil`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68924c801a08832eac82624d4fad9a4e