### PR TITLE
Add GPU window scan routine

### DIFF
--- a/CudaKeySearchDevice/CudaPollardDevice.cpp
+++ b/CudaKeySearchDevice/CudaPollardDevice.cpp
@@ -3,9 +3,29 @@
 #include <vector>
 #include <cstring>
 #include <cstdint>
+#include <unordered_set>
+#include <algorithm>
 
 
 using namespace secp256k1;
+
+struct MatchRecord {
+    uint32_t offset;
+    uint32_t fragment;
+    uint64_t k;
+};
+
+extern "C" void launchWindowKernel(dim3 gridDim,
+                                    dim3 blockDim,
+                                    uint64_t start_k,
+                                    uint64_t range_length,
+                                    uint32_t ws,
+                                    const uint32_t *offsets,
+                                    uint32_t offsets_count,
+                                    uint32_t mask,
+                                    const uint32_t target_fragments[][MAX_OFFSETS],
+                                    MatchRecord *out_buffer,
+                                    uint32_t *out_count);
 
 struct GpuPollardWindow {
     uint32_t targetIdx;
@@ -302,6 +322,87 @@ void CudaPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
     cudaFree(d_stride);
     if(d_windows) cudaFree(d_windows);
     cudaStreamDestroy(stream);
+}
+
+void CudaPollardDevice::scanKeyRange(uint64_t start_k,
+                                     uint64_t end_k,
+                                     uint32_t windowBits,
+                                     const uint32_t targetFragments[][MAX_OFFSETS],
+                                     std::vector<PollardEngine::Constraint> &outConstraints) {
+    uint32_t offsetsCount = static_cast<uint32_t>(_offsets.size());
+    if(offsetsCount == 0 || windowBits == 0) {
+        return;
+    }
+    uint32_t mask = (windowBits >= 32) ? 0xffffffffu : ((1u << windowBits) - 1u);
+
+    uint32_t *d_offsets = nullptr;
+    uint32_t (*d_targets)[MAX_OFFSETS] = nullptr;
+    MatchRecord *d_out = nullptr;
+    uint32_t *d_count = nullptr;
+
+    cudaMalloc(&d_offsets, offsetsCount * sizeof(uint32_t));
+    cudaMalloc(&d_targets, windowBits * MAX_OFFSETS * sizeof(uint32_t));
+    cudaMalloc(&d_out, sizeof(MatchRecord) * 1024);
+    cudaMalloc(&d_count, sizeof(uint32_t));
+
+    cudaMemcpy(d_offsets, _offsets.data(), offsetsCount * sizeof(uint32_t), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_targets, targetFragments, windowBits * MAX_OFFSETS * sizeof(uint32_t), cudaMemcpyHostToDevice);
+
+    std::vector<MatchRecord> hostOut(1024);
+    std::unordered_set<uint32_t> seen;
+
+    uint64_t chunk = (1ULL << 32);
+    for(uint64_t chunkStart = start_k; chunkStart < end_k && seen.size() < offsetsCount; chunkStart += chunk) {
+        uint64_t range = std::min(chunk, end_k - chunkStart);
+        dim3 block(256);
+        dim3 grid((range + block.x - 1) / block.x);
+
+        cudaMemset(d_count, 0, sizeof(uint32_t));
+        launchWindowKernel(grid, block, chunkStart, range, windowBits,
+                           d_offsets, offsetsCount, mask, d_targets, d_out, d_count);
+
+        uint32_t hCount = 0;
+        cudaMemcpy(&hCount, d_count, sizeof(uint32_t), cudaMemcpyDeviceToHost);
+        if(hCount > hostOut.size()) hCount = hostOut.size();
+        cudaMemcpy(hostOut.data(), d_out, hCount * sizeof(MatchRecord), cudaMemcpyDeviceToHost);
+
+        for(uint32_t i = 0; i < hCount; ++i) {
+            const MatchRecord &r = hostOut[i];
+            if(!seen.insert(r.offset).second) {
+                continue;
+            }
+
+            uint32_t modBits = r.offset + windowBits;
+            secp256k1::uint256 rem(0);
+            uint64_t frag = static_cast<uint64_t>(r.fragment & mask);
+            uint32_t word = r.offset / 32;
+            uint32_t bit = r.offset % 32;
+            if(word < 8) {
+                rem.v[word] |= static_cast<uint32_t>(frag << bit);
+                if(bit && word + 1 < 8) {
+                    rem.v[word + 1] |= static_cast<uint32_t>(frag >> (32 - bit));
+                }
+            }
+
+            secp256k1::uint256 mod(0);
+            if(modBits < 256) {
+                mod.v[modBits / 32] = (1u << (modBits % 32));
+            }
+            outConstraints.push_back({mod, rem});
+
+            PollardWindow w;
+            w.targetIdx = 0;
+            w.offset = r.offset;
+            w.bits = windowBits;
+            w.scalarFragment = rem;
+            _engine.processWindow(w);
+        }
+    }
+
+    cudaFree(d_offsets);
+    cudaFree(d_targets);
+    cudaFree(d_out);
+    cudaFree(d_count);
 }
 
 extern "C" bool runCudaHashWindowLE(const unsigned int h[5], unsigned int offset,

--- a/CudaKeySearchDevice/CudaPollardDevice.h
+++ b/CudaKeySearchDevice/CudaPollardDevice.h
@@ -5,6 +5,8 @@
 #include <array>
 #include "../KeyFinder/PollardEngine.h"
 
+static const unsigned int MAX_OFFSETS = 32;
+
 class CudaPollardDevice : public PollardDevice {
     PollardEngine &_engine;
     unsigned int _windowBits;
@@ -26,6 +28,22 @@ public:
     void startWildWalk(const secp256k1::uint256 &start, uint64_t steps,
                        const secp256k1::uint256 &seed, bool sequential) override;
     bool popResult(PollardMatch &out) override { (void)out; return false; }
+
+    /**
+     * Enumerate a key range using the ``windowKernel`` and forward any
+     * recovered window constraints to the associated ``PollardEngine``.
+     *
+     * ``targetFragments`` is a two dimensional array where each row contains
+     * the expected fragment for every configured offset.  The number of rows
+     * must equal ``windowBits`` which also determines the mask applied to the
+     * extracted fragments.  Constraints for each discovered offset are appended
+     * to ``outConstraints``.
+     */
+    void scanKeyRange(uint64_t start_k,
+                      uint64_t end_k,
+                      uint32_t windowBits,
+                      const uint32_t targetFragments[][MAX_OFFSETS],
+                      std::vector<PollardEngine::Constraint> &outConstraints);
 };
 
 #endif


### PR DESCRIPTION
## Summary
- add scanKeyRange helper to run `windowKernel` over key ranges and forward matches to CRT logic

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68925fa15fc0832eaddf1a2e5d195e3b