### PR TITLE
Use MatchRecord for window constraints

### DIFF
--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -47,12 +47,6 @@ struct CudaPollardMatch {
 };
 
 #define MAX_OFFSETS 32
-
-struct MatchRecord {
-    uint32_t offset;
-    uint32_t fragment;
-    uint64_t k;
-};
 __device__ static inline uint64_t xorshift128plus(RNGState &state)
 {
     uint64_t x = state.s0;

--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -65,11 +65,12 @@ public:
     bool reconstruct(size_t target, secp256k1::uint256 &k0,
                      secp256k1::uint256 &modulus);
 
-    // Consume a window result produced by a GPU kernel or converted from a
-    // CPU device.  This function accumulates the constraint, attempts key
-    // reconstruction and, on success, hashes the candidate to verify it
-    // belongs to the supplied target set before invoking the callback.
-    void processWindow(const PollardWindow &w);
+    // Consume a window constraint produced by a device. This function
+    // accumulates the constraint, attempts key reconstruction and, on success,
+    // hashes the candidate to verify it belongs to the supplied target set
+    // before invoking the callback.
+    void processWindow(size_t targetIdx, unsigned int offset,
+                       const Constraint &c);
 
     // Walk routines consume results produced by the configured device.  The
     // overloads with a seed parameter enable deterministic behaviour for

--- a/KeyFinder/PollardTypes.h
+++ b/KeyFinder/PollardTypes.h
@@ -1,6 +1,7 @@
 #ifndef POLLARD_TYPES_H
 #define POLLARD_TYPES_H
 #include "secp256k1.h"
+#include <cstdint>
 
 // Hashes within the Pollard engine are stored in little-endian word order so
 // that bit offset 0 corresponds to the least significant bit of the RIPEMD160
@@ -25,5 +26,14 @@ struct PollardWindow {
                                              // little-endian hash160
     unsigned int bits;                       // size of the window in bits
     secp256k1::uint256 scalarFragment;       // full scalar at the match
+};
+
+// Compact record emitted by ``windowKernel`` during key range scans. Each
+// entry captures the window offset, the extracted fragment of the x-coordinate
+// and the corresponding scalar ``k`` where the match occurred.
+struct MatchRecord {
+    uint32_t offset;   // bit offset within the x-coordinate
+    uint32_t fragment; // extracted window fragment
+    uint64_t k;        // scalar at the match
 };
 #endif

--- a/PollardTests/main.cpp
+++ b/PollardTests/main.cpp
@@ -792,9 +792,6 @@ bool testCRTMixedOffsetsPython() {
     std::vector<Pair> constraints;
 
     for(size_t i = 0; i < offsets.size(); ++i) {
-        PollardWindow w{0u, offsets[i], sizes[i], key};
-        engine.processWindow(w);
-
         unsigned int modBits = offsets[i] + sizes[i];
         uint256 mod(0);
         if(modBits < 256) {
@@ -812,6 +809,8 @@ bool testCRTMixedOffsetsPython() {
                 for(unsigned int j = word; j < 8; ++j) rem.v[j] = 0u;
             }
         }
+        PollardEngine::Constraint c{mod, rem};
+        engine.processWindow(0, offsets[i], c);
         constraints.push_back({mod, rem});
     }
 


### PR DESCRIPTION
## Summary
- Add a shared `MatchRecord` struct for windowKernel results
- Process Pollard constraints directly via `processWindow` with target/offset
- Translate GPU `MatchRecord` outputs into constraints on the host before CRT reconstruction

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6892622ef7b0832eb2b0c6c6508acdf1