### PR TITLE
Add configurable CUDA launch dimensions

### DIFF
--- a/CudaKeySearchDevice/CudaPollardDevice.h
+++ b/CudaKeySearchDevice/CudaPollardDevice.h
@@ -14,6 +14,8 @@ class CudaPollardDevice : public PollardDevice {
     // RIPEMD160 hashes in little-endian word order
     std::vector<std::array<unsigned int,5>> _targets;
     bool _debug;
+    unsigned int _gridDim;
+    unsigned int _blockDim;
 public:
     CudaPollardDevice(PollardEngine &engine,
                       unsigned int windowBits,
@@ -21,7 +23,9 @@ public:
                       // ``targets`` must contain RIPEMD160 hashes in
                       // little-endian word order
                       const std::vector<std::array<unsigned int,5>> &targets,
-                      bool debug);
+                      bool debug,
+                      unsigned int gridDim = 0,
+                      unsigned int blockDim = 0);
 
     void startTameWalk(const secp256k1::uint256 &start, uint64_t steps,
                        const secp256k1::uint256 &seed, bool sequential) override;


### PR DESCRIPTION
## Summary
- allow configuring CUDA grid and block dimensions for Pollard kernels
- expose `--grid-dim` and `--block-dim` command line options and checkpoint support
- validate launch dimensions against device limits before kernel dispatch

## Testing
- `make`
- `make BUILD_CUDA=1 dir_cudaKeySearchDevice` *(fails: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689264cdb4f8832e862d40c8628c857b