### PR TITLE
Expose windowKernel for Pollard engine

### DIFF
--- a/CudaKeySearchDevice/windowKernel.h
+++ b/CudaKeySearchDevice/windowKernel.h
@@ -1,0 +1,18 @@
+#ifndef WINDOW_KERNEL_H
+#define WINDOW_KERNEL_H
+
+#include <cstdint>
+#include "../KeyFinder/PollardTypes.h"
+
+#ifdef __CUDACC__
+extern "C" __global__ void windowKernel(uint64_t start_k,
+                                         uint64_t range_len,
+                                         int ws,
+                                         const uint32_t *offsets,
+                                         uint32_t mask,
+                                         const uint32_t *target_frags,
+                                         MatchRecord *out_buf,
+                                         unsigned int *out_count);
+#endif
+
+#endif // WINDOW_KERNEL_H

--- a/KeyFinder/PollardEngine.cpp
+++ b/KeyFinder/PollardEngine.cpp
@@ -1,6 +1,7 @@
 #include "PollardEngine.h"
 #include "secp256k1.h"
 #include "AddressUtil.h"
+#include "../CudaKeySearchDevice/windowKernel.h"
 #include <algorithm>
 #include <cstring>
 #include <vector>


### PR DESCRIPTION
## Summary
- add window kernel header declaring MatchRecord and windowKernel prototype
- include the kernel header in PollardEngine

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68926c6f87bc832eb446cb2e50a8c6ad