### PR TITLE
Compile windowKernel in CUDA build

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -1,10 +1,13 @@
 CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
+CUSRC=../CudaKeySearchDevice/windowKernel.cu
+CUOBJ=windowKernel.o
 
 all:
 ifeq ($(BUILD_CUDA), 1)
-	${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
-	mkdir -p $(BINDIR)
-	cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
+        ${NVCC} -c ${CUSRC} -o ${CUOBJ} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
+        ${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${CUOBJ} ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
+        mkdir -p $(BINDIR)
+        cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif
 ifeq ($(BUILD_OPENCL),1)
 	${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
@@ -18,6 +21,7 @@ ifeq ($(CPU),1)
 endif
 
 clean:
-	rm -rf cuKeyFinder.bin
-	rm -rf clKeyFinder.bin
-	rm -rf KeyFinder.bin
+        rm -rf cuKeyFinder.bin
+        rm -rf clKeyFinder.bin
+        rm -rf KeyFinder.bin
+        rm -rf ${CUOBJ}


### PR DESCRIPTION
## Summary
- Compile `CudaKeySearchDevice/windowKernel.cu` and link its object into `cuKeyFinder.bin`
- Clean up generated `windowKernel.o` in `make clean`

## Testing
- `make dir_keyfinder BUILD_CUDA=1` *(fails: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689270d325c4832ebbf4f93d0048bf13