### PR TITLE
Fix KeyFinder Makefile recipe separators

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -4,10 +4,10 @@ CUOBJ=windowKernel.o
 
 all:
 ifeq ($(BUILD_CUDA), 1)
-        ${NVCC} -c ${CUSRC} -o ${CUOBJ} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
-        ${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${CUOBJ} ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
-        mkdir -p $(BINDIR)
-        cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
+	${NVCC} -c ${CUSRC} -o ${CUOBJ} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
+	${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${CUOBJ} ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
+	mkdir -p $(BINDIR)
+	cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif
 ifeq ($(BUILD_OPENCL),1)
 	${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
@@ -21,7 +21,7 @@ ifeq ($(CPU),1)
 endif
 
 clean:
-        rm -rf cuKeyFinder.bin
-        rm -rf clKeyFinder.bin
-        rm -rf KeyFinder.bin
-        rm -rf ${CUOBJ}
+	rm -rf cuKeyFinder.bin
+	rm -rf clKeyFinder.bin
+	rm -rf KeyFinder.bin
+	rm -rf ${CUOBJ}


### PR DESCRIPTION
## Summary
- replace spaces with tabs in `KeyFinder/Makefile` recipes

## Testing
- `cd KeyFinder && make clean`
- `make BUILD_CUDA=0 BUILD_OPENCL=0 CPU=0`


------
https://chatgpt.com/codex/tasks/task_e_68927e57b574832e81319ab59c4fe380