### PR TITLE
Link Pollard tests against pthread and CUDA libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,12 @@ dir_addrgen:	dir_cmdparse dir_addressutil dir_secp256k1lib
 dir_clunittest: dir_clutil
 	make --directory CLUnitTests
 
-dir_pollardtests: dir_secp256k1lib dir_cryptoutil dir_util dir_addressutil dir_logger
+POLLARDTESTS_DEPS=dir_secp256k1lib dir_cryptoutil dir_util dir_addressutil dir_logger
+ifeq ($(BUILD_CUDA),1)
+    POLLARDTESTS_DEPS:=$(POLLARDTESTS_DEPS) dir_cudautil dir_cudaKeySearchDevice
+endif
+
+dir_pollardtests: $(POLLARDTESTS_DEPS)
 	make --directory PollardTests
 
 pollard-tests: dir_pollardtests

--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -17,7 +17,7 @@ endif
 
 CXXFLAGS+=-DBUILD_CUDA=$(BUILD_CUDA) -DBUILD_OPENCL=$(BUILD_OPENCL)
 
-LIBS_LOCAL=-laddressutil -lsecp256k1 -lcryptoutil -lutil -llogger
+LIBS_LOCAL=-laddressutil -lsecp256k1 -lcryptoutil -lutil -llogger -pthread
 ifeq ($(BUILD_OPENCL),1)
 LIBS_LOCAL+=-lclutil -lutil -lOpenCL -L${OPENCL_LIB} -lCLKeySearchDevice
 endif


### PR DESCRIPTION
## Summary
- Ensure Pollard tests link with pthread.
- Build CUDA utilities before Pollard tests when CUDA support is enabled.

## Testing
- `make dir_pollardtests BUILD_CUDA=1` *(fails: cudaUtil.h: No such file or directory)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689289646024832ebb302cb6751cc4af