### PR TITLE
Rely on library kernel for KeyFinder build

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -1,11 +1,8 @@
 CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
-CUSRC=../CudaKeySearchDevice/windowKernel.cu
-CUOBJ=windowKernel.o
 
 all:
 ifeq ($(BUILD_CUDA), 1)
-	${NVCC} -c ${CUSRC} -o ${CUOBJ} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
-	${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${CUOBJ} ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
+	${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
 	mkdir -p $(BINDIR)
 	cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif
@@ -24,4 +21,3 @@ clean:
 	rm -rf cuKeyFinder.bin
 	rm -rf clKeyFinder.bin
 	rm -rf KeyFinder.bin
-	rm -rf ${CUOBJ}


### PR DESCRIPTION
## Summary
- Drop direct `windowKernel.cu` compilation in KeyFinder; link against `libCudaKeySearchDevice.a` instead.
- Simplify build and clean rules accordingly.

## Testing
- `make clean`
- `make BUILD_CUDA=1` *(fails: cudaUtil.h:4:10: fatal error: cuda.h: No such file or directory)*
- `apt-get update` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68928be81034832e9c262b44efdc5b46