### PR TITLE
refactor: move window kernel definitions

### DIFF
--- a/CudaKeySearchDevice/windowKernel.h
+++ b/CudaKeySearchDevice/windowKernel.h
@@ -2,6 +2,11 @@
 #define WINDOW_KERNEL_H
 
 #include <cstdint>
+#ifdef __CUDACC__
+#include <cuda_runtime.h>
+#else
+struct dim3 { unsigned int x, y, z; dim3(unsigned int vx=1, unsigned int vy=1, unsigned int vz=1) : x(vx), y(vy), z(vz) {} };
+#endif
 #include "../KeyFinder/PollardTypes.h"
 
 #ifdef __CUDACC__
@@ -14,5 +19,16 @@ extern "C" __global__ void windowKernel(uint64_t start_k,
                                          MatchRecord *out_buf,
                                          unsigned int *out_count);
 #endif
+
+extern "C" void launchWindowKernel(dim3 gridDim,
+                                   dim3 blockDim,
+                                   uint64_t start_k,
+                                   uint64_t range_len,
+                                   int ws,
+                                   const uint32_t *offsets,
+                                   uint32_t mask,
+                                   const uint32_t *target_frags,
+                                   MatchRecord *out_buf,
+                                   unsigned int *out_count);
 
 #endif // WINDOW_KERNEL_H


### PR DESCRIPTION
## Summary
- drop windowKernel and its launcher from CudaPollard.cu, leaving only legacy walk kernels
- expose launchWindowKernel from windowKernel.cu and declare it in windowKernel.h
- include the new header where kernels are launched and update scanKeyRange to call the wrapper

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68929503b784832eaf0b10b62026d3e0