### PR TITLE
Use NVCC to build PollardTests with CUDA support

### DIFF
--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -1,5 +1,8 @@
 NAME=PollardTests
-CPPSRC=main.cpp ../KeyFinder/PollardEngine.cpp
+CPPSRC=main.cpp
+ifeq ($(BUILD_CUDA),0)
+CPPSRC+=../KeyFinder/PollardEngine.cpp
+endif
 CUDASRC=cuda_scalar_one.cu
 BINDIR?=.
 
@@ -12,7 +15,7 @@ BUILD_OPENCL:=$(if $(BUILD_OPENCL),$(BUILD_OPENCL),0)
 
 OBJS=
 ifeq ($(BUILD_CUDA),1)
-OBJS+=cuda_scalar_one.o
+OBJS+=cuda_scalar_one.o PollardEngine.o
 endif
 
 CXXFLAGS+=-DBUILD_CUDA=$(BUILD_CUDA) -DBUILD_OPENCL=$(BUILD_OPENCL)
@@ -26,7 +29,11 @@ LIBS_LOCAL+=-lcudart -L${CUDA_LIB} -lCudaKeySearchDevice
 endif
 
 all: $(OBJS)
+ifeq ($(BUILD_CUDA),1)
+;${NVCC} ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH} -o pollardtests.bin ${CPPSRC} $(OBJS) ${LIBS} ${LIBS_LOCAL}
+else
 ;${CXX} -o pollardtests.bin ${CPPSRC} $(OBJS) ${INCLUDE} ${CXXFLAGS} ${LIBS} ${LIBS_LOCAL}
+endif
 ;mkdir -p $(BINDIR)
 ;cp pollardtests.bin $(BINDIR)/pollardtests
 
@@ -34,5 +41,8 @@ cuda_scalar_one.o: cuda_scalar_one.cu
 ;${NVCC} -c cuda_scalar_one.cu -o cuda_scalar_one.o ${NVCCFLAGS} \
     -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
 
+PollardEngine.o: ../KeyFinder/PollardEngine.cpp
+;${NVCC} -c ../KeyFinder/PollardEngine.cpp -o PollardEngine.o ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
+
 clean:
-;rm -f pollardtests.bin cuda_scalar_one.o
+;rm -f pollardtests.bin cuda_scalar_one.o PollardEngine.o


### PR DESCRIPTION
## Summary
- Compile PollardEngine.cpp with NVCC when `BUILD_CUDA=1`
- Link `pollardtests` with NVCC and CUDA libraries
- Pass `-DBUILD_CUDA=1` and CUDA include paths during compilation

## Testing
- `BUILD_CUDA=1 make dir_pollardtests` *(fails: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689298997000832e9543115bcec12e32