### PR TITLE
Use windowKernel launcher in Pollard engine

### DIFF
--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -12,7 +12,7 @@
 #include "KeySearchDevice.h"
 #include "PollardTypes.h"  // for MatchRecord
 #if BUILD_CUDA
-#include "../CudaKeySearchDevice/windowKernel.h"
+#include "windowKernel.h"
 #endif
 
 class PollardDevice {


### PR DESCRIPTION
## Summary
- include `windowKernel.h` in Pollard engine components instead of manual externs
- allocate fragments as a 1-D array and use updated `launchWindowKernel` interface

## Testing
- `make test` *(fails: undefined reference to `PollardEngine::PollardEngine` et al.)*

------
https://chatgpt.com/codex/tasks/task_e_68929abda074832eb6ef821dd87f6158