### PR TITLE
Fix PollardTests build flag initialization

### DIFF
--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -1,4 +1,6 @@
 NAME=PollardTests
+BUILD_CUDA?=0
+BUILD_OPENCL?=0
 CPPSRC=main.cpp
 ifeq ($(BUILD_CUDA),0)
 CPPSRC+=../KeyFinder/PollardEngine.cpp
@@ -6,8 +8,6 @@ endif
 CUDASRC=cuda_scalar_one.cu
 BINDIR?=.
 
-BUILD_CUDA?=0
-BUILD_OPENCL?=0
 BUILD_CUDA:=$(if $(BUILD_CUDA),$(BUILD_CUDA),0)
 BUILD_OPENCL:=$(if $(BUILD_OPENCL),$(BUILD_OPENCL),0)
 


### PR DESCRIPTION
## Summary
- define CUDA and OpenCL build flags before the first conditional so CPU builds evaluate correctly
- ensure PollardEngine.cpp is included in CPPSRC when CUDA is disabled

## Testing
- `make pollard-tests BUILD_CUDA=0 BUILD_OPENCL=0`
- `./bin/pollardtests` *(tests skipped: GPU not available)*

------
https://chatgpt.com/codex/tasks/task_e_6892a77e5b40832eb4acf7c9467a39d5