### PR TITLE
Clamp and guard Pollard hit buffer

### DIFF
--- a/KeyFinder/PollardEngine.cpp
+++ b/KeyFinder/PollardEngine.cpp
@@ -604,8 +604,10 @@ void PollardEngine::enumerateCandidates(const uint256 &k0, const uint256 &modulu
         // Retrieve matches.
         uint32_t hitCount = 0;
         cudaMemcpy(&hitCount, dev_count, sizeof(uint32_t), cudaMemcpyDeviceToHost);
+        hitCount = std::min(hitCount, 1024u);
+
         std::vector<MatchRecord> hostBuf(hitCount);
-        if(hitCount) {
+        if(hitCount != 0) {
             cudaMemcpy(hostBuf.data(), dev_out,
                        hitCount * sizeof(MatchRecord), cudaMemcpyDeviceToHost);
         }


### PR DESCRIPTION
## Summary
- clamp GPU Pollard match count to device buffer size
- only copy matches when device reports a non-zero count

## Testing
- `make test` *(fails: undefined reference to `PollardEngine` symbols)*

------
https://chatgpt.com/codex/tasks/task_e_6892a92c4370832e8339c41b8671e922