### PR TITLE
Move Pollard window matching onto GPU

### DIFF
--- a/CudaKeySearchDevice/windowKernel.h
+++ b/CudaKeySearchDevice/windowKernel.h
@@ -2,17 +2,7 @@
 #define WINDOW_KERNEL_H
 
 #include <cstdint>
-
-// ``dim3`` is provided by ``<cuda_runtime.h>`` when compiling with NVCC.
-#ifndef __CUDACC__
-struct dim3 {
-    unsigned int x, y, z;
-    dim3(unsigned int vx = 1, unsigned int vy = 1, unsigned int vz = 1)
-        : x(vx), y(vy), z(vz) {}
-};
-#else
 #include <cuda_runtime.h>
-#endif
 
 // Minimal record emitted by ``windowKernel`` describing a matching window.
 struct MatchRecord {

--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -1,6 +1,10 @@
 NAME=PollardTests
-BUILD_CUDA?=0
-BUILD_OPENCL?=0
+ifeq ($(strip $(BUILD_CUDA)),)
+BUILD_CUDA=0
+endif
+ifeq ($(strip $(BUILD_OPENCL)),)
+BUILD_OPENCL=0
+endif
 CPPSRC=main.cpp
 ifeq ($(BUILD_CUDA),0)
 CPPSRC+=../KeyFinder/PollardEngine.cpp
@@ -8,8 +12,6 @@ endif
 CUDASRC=cuda_scalar_one.cu
 BINDIR?=.
 
-BUILD_CUDA:=$(if $(BUILD_CUDA),$(BUILD_CUDA),0)
-BUILD_OPENCL:=$(if $(BUILD_OPENCL),$(BUILD_OPENCL),0)
 
 .RECIPEPREFIX := ;
 
@@ -32,7 +34,7 @@ all: $(OBJS)
 ifeq ($(BUILD_CUDA),1)
 ;${NVCC} ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH} -o pollardtests.bin ${CPPSRC} $(OBJS) ${LIBS} ${LIBS_LOCAL}
 else
-;${CXX} -o pollardtests.bin ${CPPSRC} $(OBJS) ${INCLUDE} ${CXXFLAGS} ${LIBS} ${LIBS_LOCAL}
+;${CXX} ${CXXFLAGS} ${INCLUDE} -o pollardtests.bin ${CPPSRC} $(OBJS) ${LIBS} ${LIBS_LOCAL}
 endif
 ;mkdir -p $(BINDIR)
 ;cp pollardtests.bin $(BINDIR)/pollardtests
@@ -42,7 +44,9 @@ cuda_scalar_one.o: cuda_scalar_one.cu
     -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
 
 PollardEngine.o: ../KeyFinder/PollardEngine.cpp
-;${NVCC} -c ../KeyFinder/PollardEngine.cpp -o PollardEngine.o ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
+;${NVCC} -c ../KeyFinder/PollardEngine.cpp -o PollardEngine.o ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) \
+    ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
 
 clean:
 ;rm -f pollardtests.bin cuda_scalar_one.o PollardEngine.o
+


### PR DESCRIPTION
## Summary
- Simplify CUDA window kernel header and expose launch wrapper
- Offload PollardEngine window extraction to GPU using `windowKernel`
- Fix PollardTests build system to handle CUDA/CPU compilation

## Testing
- `make BUILD_CUDA=1` *(fails: cudaUtil.h:4:10: fatal error: cuda.h: No such file or directory)*
- `make pollard-tests`
- `./bin/pollardtests`


------
https://chatgpt.com/codex/tasks/task_e_689269a75f6c832ead1cd2ae06516334