### PR TITLE
Use uint256 for Pollard hash windows

### DIFF
--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -89,11 +89,11 @@ public:
     void setDevice(std::unique_ptr<PollardDevice> device);
 
     // Public wrapper exposing the internal hashWindow helper.  ``h`` must be
-    // supplied in little-endian word order.  The returned array contains the
-    // extracted window as five 32-bit words with unused high words set to
-    // zero.
-    static std::array<unsigned int,5> publicHashWindow(const unsigned int h[5], unsigned int offset,
-                                                       unsigned int bits);
+    // supplied in little-endian word order.  The returned ``uint256`` contains
+    // the extracted window in little-endian format with unused high words
+    // cleared.
+    static secp256k1::uint256 publicHashWindow(const unsigned int h[5], unsigned int offset,
+                                               unsigned int bits);
 
 private:
     struct TargetState {
@@ -140,8 +140,8 @@ private:
     void handleMatch(const PollardMatch &m);
     void pollDevice();
 
-    static std::array<unsigned int,5> hashWindow(const unsigned int h[5], unsigned int offset,
-                                                 unsigned int bits);
+    static secp256k1::uint256 hashWindow(const unsigned int h[5], unsigned int offset,
+                                         unsigned int bits);
 };
 
 #endif

--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -595,10 +595,8 @@ int runPollard()
     for(size_t t = 0; t < targetHashes.size(); ++t) {
         for(unsigned int off : offsets) {
             unsigned int bits = off + window;
-            auto remWords = PollardEngine::publicHashWindow(targetHashes[t].data(), off, window);
-            secp256k1::uint256 rem;
-            for(int i = 0; i < 5; ++i) rem.v[i] = remWords[i];
-            for(int i = 5; i < 8; ++i) rem.v[i] = 0u;
+            secp256k1::uint256 rem =
+                PollardEngine::publicHashWindow(targetHashes[t].data(), off, window);
             std::string modStr;
             if(bits >= 256) {
                 modStr = "2^256";


### PR DESCRIPTION
## Summary
- Replace 64-bit masks with uint256-based checks in Pollard engine and CPU device
- Extract hash windows into uint256 values and compute fragments from them
- Return uint256 from hashWindow helpers and update callers accordingly

## Testing
- `make test CPU=1`

------
https://chatgpt.com/codex/tasks/task_e_6892b94b1d78832eb3f3fe9660101fc0