### PR TITLE
Refactor Pollard GPU window search

### DIFF
--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -7,6 +7,10 @@
 #include "secp256k1.cuh" // EC point operations
 #include "ptx.cuh"       // byte order helpers
 
+// The legacy ``windowKernel`` previously lived in this translation unit.  It
+// has been moved to ``windowKernel.cu`` to avoid duplicate definitions and keep
+// this file focused on the Pollard walk kernels.
+
 __device__ void hashPublicKeyCompressed(const uint32_t*, uint32_t, uint32_t*);
 
 #define CUDA_CHECK(call) do { \

--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -1,6 +1,8 @@
 NAME=CudaKeySearchDevice
 CPPSRC:=$(wildcard *.cpp)
-CUSRC:=$(wildcard *.cu)
+# ``windowKernel.cu`` is built and linked directly by the KeyFinder executable,
+# so exclude it from the device library to avoid duplicate definitions.
+CUSRC:=$(filter-out windowKernel.cu, $(wildcard *.cu))
 MATHSRC:=$(CUDA_MATH)/sha256_constants.cu $(CUDA_MATH)/ripemd160_constants.cu
 
 .RECIPEPREFIX := ;

--- a/CudaKeySearchDevice/windowKernel.cu
+++ b/CudaKeySearchDevice/windowKernel.cu
@@ -1,5 +1,4 @@
 #include <stdint.h>
-#include <cuda_runtime.h>
 #include <cstdio>
 
 #include "secp256k1.cuh"
@@ -170,6 +169,11 @@ __device__ static inline void point_mul_G(const uint32_t k[8], uint32_t X[8], ui
 
 // -----------------------------------------------------------------------------
 
+// ``windowKernel`` performs a simple grid-stride loop over the supplied scalar
+// range.  For each ``k`` it computes ``k * G`` and tests user supplied bit
+// windows of the X coordinate against the corresponding target fragments.  Any
+// match results in a ``MatchRecord`` being appended to ``out_buf`` via an
+// atomic counter.
 extern "C" __global__ void windowKernel(uint64_t start_k,
                                          uint64_t range_len,
                                          uint32_t ws,
@@ -207,6 +211,7 @@ extern "C" __global__ void windowKernel(uint64_t start_k,
             }
             uint32_t frag = (uint32_t)val & mask;
             if(frag == target_frags[i]) {
+                // Record the matching fragment and the scalar ``k``.
                 uint32_t outIdx = atomicAdd(out_count, 1u);
                 out_buf[outIdx].offset   = off;
                 out_buf[outIdx].fragment = frag;
@@ -216,6 +221,8 @@ extern "C" __global__ void windowKernel(uint64_t start_k,
     }
 }
 
+// Host wrapper used by C++ code.  It exposes the launch configuration so the
+// caller can tune grid and block sizes and performs basic CUDA error checking.
 extern "C" void launchWindowKernel(dim3 gridDim,
                                    dim3 blockDim,
                                    uint64_t start_k,
@@ -227,7 +234,6 @@ extern "C" void launchWindowKernel(dim3 gridDim,
                                    const uint32_t *target_frags,
                                    MatchRecord *out_buf,
                                    uint32_t *out_count) {
-    // Launch the kernel and check for launch/runtime errors.
     windowKernel<<<gridDim, blockDim>>>(start_k, range_len, ws, offsets,
                                         offsets_count, mask, target_frags,
                                         out_buf, out_count);

--- a/CudaKeySearchDevice/windowKernel.h
+++ b/CudaKeySearchDevice/windowKernel.h
@@ -2,28 +2,27 @@
 #define WINDOW_KERNEL_H
 
 #include <cstdint>
+
+// When compiling without CUDA headers (e.g. unit tests on the host), provide a
+// minimal ``dim3`` replacement to keep the interface compatible.  The
+// definition is skipped when the real CUDA ``dim3`` is available to avoid
+// multiple-definition errors.
+#ifndef __CUDACC__
+struct dim3 { unsigned int x, y, z; dim3(unsigned int a=1, unsigned int b=1, unsigned int c=1) : x(a), y(b), z(c) {} };
+#else
 #include <cuda_runtime.h>
+#endif
 
 // Minimal record emitted by ``windowKernel`` describing a matching window.
 struct MatchRecord {
-    uint32_t offset;      // bit offset of the window
-    uint32_t fragment;    // extracted fragment of the x-coordinate
-    uint64_t k;           // scalar where the match occurred
+    uint32_t offset;    // bit offset of the window
+    uint32_t fragment;  // extracted fragment of the x-coordinate
+    uint64_t k;         // scalar where the match occurred
 };
 
-#ifdef __CUDACC__
-extern "C" __global__ void windowKernel(uint64_t start_k,
-                                         uint64_t range_len,
-                                         uint32_t ws,
-                                         const uint32_t *offsets,
-                                         uint32_t offsets_count,
-                                         uint32_t mask,
-                                         const uint32_t *target_frags,
-                                         MatchRecord *out_buf,
-                                         uint32_t *out_count);
-#endif
-
-// Host-side wrapper used to launch ``windowKernel`` from C++ code.
+// Host-side wrapper used to launch ``windowKernel`` from C++ code.  The grid
+// and block dimensions are passed in so callers can tune occupancy as
+// required.
 extern "C" void launchWindowKernel(dim3 gridDim,
                                    dim3 blockDim,
                                    uint64_t start_k,

--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -1,10 +1,19 @@
 CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
+# CUDA kernel sources used directly by the KeyFinder when BUILD_CUDA=1.
+KERNELSRC=../CudaKeySearchDevice/windowKernel.cu
+.RECIPEPREFIX := ;
 
 all:
 ifeq ($(BUILD_CUDA), 1)
-	${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
-	mkdir -p $(BINDIR)
-	cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
+;# Build the window kernel with NVCC so it can be linked into the final binary.
+;${NVCC} -x cu -c $(KERNELSRC) -o windowKernel.cu.o ${NVCCFLAGS} \
+;        -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I../cudaMath
+;# Compile and link the main application with NVCC to enable CUDA code inside PollardEngine.cpp.
+;${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} windowKernel.cu.o ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} \
+;        -gencode=arch=compute_89,code=sm_89 ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 \
+;        -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
+;mkdir -p $(BINDIR)
+;cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif
 ifeq ($(BUILD_OPENCL),1)
 	${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
@@ -18,6 +27,6 @@ ifeq ($(CPU),1)
 endif
 
 clean:
-	rm -rf cuKeyFinder.bin
-	rm -rf clKeyFinder.bin
-	rm -rf KeyFinder.bin
+;rm -rf cuKeyFinder.bin
+;rm -rf clKeyFinder.bin
+;rm -rf KeyFinder.bin

--- a/KeyFinder/PollardEngine.cpp
+++ b/KeyFinder/PollardEngine.cpp
@@ -643,14 +643,14 @@ void PollardEngine::enumerateCandidates(const uint256 &k0, const uint256 &modulu
                        hitCount * sizeof(MatchRecord), cudaMemcpyDeviceToHost));
         }
 
-        // Validate each matching candidate by computing its full hash.
+        // Convert each hit into a CRT constraint and pass it back through the
+        // existing window processing path.  The CRT merge and final
+        // verification logic remain unchanged.
         for(const auto &rec : hostBuf) {
-            uint256 priv(rec.k);
-            if(priv.cmp(L) < 0 || priv.cmp(U) > 0) {
-                continue;
-            }
-            ecpoint pub = multiplyPoint(priv, G());
-            enumerateCandidate(priv, pub);
+            uint32_t mod = 1u << (rec.offset + ws);
+            uint32_t rem = (rec.fragment << rec.offset) & (mod - 1);
+            Constraint c{uint256(mod), uint256(rem)};
+            processWindow(t, rec.offset, c);
         }
     }
 

--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -12,6 +12,7 @@
 #include "KeySearchDevice.h"
 #include "PollardTypes.h"  // basic Pollard structures
 #if BUILD_CUDA
+// Interface to the lightweight GPU window matching kernel.
 #include "windowKernel.h"
 #endif
 

--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -17,7 +17,7 @@ BINDIR?=.
 
 OBJS=
 ifeq ($(BUILD_CUDA),1)
-OBJS+=cuda_scalar_one.o PollardEngine.o
+OBJS+=cuda_scalar_one.o PollardEngine.o main.o windowKernel.o
 endif
 
 CXXFLAGS+=-DBUILD_CUDA=$(BUILD_CUDA) -DBUILD_OPENCL=$(BUILD_OPENCL)
@@ -32,7 +32,7 @@ endif
 
 all: $(OBJS)
 ifeq ($(BUILD_CUDA),1)
-;${NVCC} ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH} -o pollardtests.bin ${CPPSRC} $(OBJS) ${LIBS} ${LIBS_LOCAL}
+;${NVCC} ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH} -o pollardtests.bin $(OBJS) ${LIBS} ${LIBS_LOCAL}
 else
 ;${CXX} ${CXXFLAGS} ${INCLUDE} -o pollardtests.bin ${CPPSRC} $(OBJS) ${LIBS} ${LIBS_LOCAL}
 endif
@@ -46,6 +46,14 @@ cuda_scalar_one.o: cuda_scalar_one.cu
 PollardEngine.o: ../KeyFinder/PollardEngine.cpp
 ;${NVCC} -c ../KeyFinder/PollardEngine.cpp -o PollardEngine.o ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) \
     ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
+
+main.o: main.cpp
+;${NVCC} -c main.cpp -o main.o ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) \
+    ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
+
+windowKernel.o: ../CudaKeySearchDevice/windowKernel.cu
+;${NVCC} -c ../CudaKeySearchDevice/windowKernel.cu -o windowKernel.o ${NVCCFLAGS} \
+    -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
 
 clean:
 ;rm -f pollardtests.bin cuda_scalar_one.o PollardEngine.o


### PR DESCRIPTION
## Summary
- add dedicated CUDA `windowKernel` for computing hash windows and return minimal match records
- route kernel hits through CRT constraint pipeline in `PollardEngine`
- update build scripts to compile CUDA sources with `nvcc` and expose configurable launch parameters

## Testing
- `make -C CudaKeySearchDevice NVCC=nvcc` *(fails: nvcc: not found)*
- `make -C KeyFinder BUILD_CUDA=1 NVCC=nvcc` *(fails: nvcc: No such file or directory)*
- `make -C PollardTests BUILD_CUDA=1 NVCC=nvcc` *(fails: nvcc: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_6892bcdb4294832ea52d6c295b96935e