### PR TITLE
Refactor window kernel integration

### DIFF
--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -7,6 +7,10 @@
 #include "secp256k1.cuh" // EC point operations
 #include "ptx.cuh"       // byte order helpers
 
+// The original prototype ``windowKernel`` implementation used by early
+// experiments has been removed from this file.  A consolidated and reusable
+// version now lives in ``windowKernel.cu``.
+
 __device__ void hashPublicKeyCompressed(const uint32_t*, uint32_t, uint32_t*);
 
 #define CUDA_CHECK(call) do { \

--- a/CudaKeySearchDevice/windowKernel.cu
+++ b/CudaKeySearchDevice/windowKernel.cu
@@ -216,9 +216,7 @@ extern "C" __global__ void windowKernel(uint64_t start_k,
     }
 }
 
-extern "C" void launchWindowKernel(dim3 gridDim,
-                                   dim3 blockDim,
-                                   uint64_t start_k,
+extern "C" void launchWindowKernel(uint64_t start_k,
                                    uint64_t range_len,
                                    uint32_t ws,
                                    const uint32_t *offsets,
@@ -227,6 +225,11 @@ extern "C" void launchWindowKernel(dim3 gridDim,
                                    const uint32_t *target_frags,
                                    MatchRecord *out_buf,
                                    uint32_t *out_count) {
+    // Compute a simple launch configuration.  The caller can modify this logic
+    // if a different grid/block size is desired.
+    dim3 blockDim(256);
+    dim3 gridDim((range_len + blockDim.x - 1) / blockDim.x);
+
     // Launch the kernel and check for launch/runtime errors.
     windowKernel<<<gridDim, blockDim>>>(start_k, range_len, ws, offsets,
                                         offsets_count, mask, target_frags,

--- a/CudaKeySearchDevice/windowKernel.h
+++ b/CudaKeySearchDevice/windowKernel.h
@@ -2,7 +2,17 @@
 #define WINDOW_KERNEL_H
 
 #include <cstdint>
-#include <cuda_runtime.h>
+
+// ``cuda_runtime.h`` is only available when compiling with NVCC.  Provide a
+// lightweight definition of ``dim3`` for host-only builds so files including
+// this header do not need the CUDA SDK.
+#ifndef __CUDACC__
+struct dim3 {
+    unsigned int x, y, z;
+    dim3(unsigned int a = 1, unsigned int b = 1, unsigned int c = 1)
+        : x(a), y(b), z(c) {}
+};
+#endif
 
 // Minimal record emitted by ``windowKernel`` describing a matching window.
 struct MatchRecord {
@@ -11,22 +21,10 @@ struct MatchRecord {
     uint64_t k;           // scalar where the match occurred
 };
 
-#ifdef __CUDACC__
-extern "C" __global__ void windowKernel(uint64_t start_k,
-                                         uint64_t range_len,
-                                         uint32_t ws,
-                                         const uint32_t *offsets,
-                                         uint32_t offsets_count,
-                                         uint32_t mask,
-                                         const uint32_t *target_frags,
-                                         MatchRecord *out_buf,
-                                         uint32_t *out_count);
-#endif
-
-// Host-side wrapper used to launch ``windowKernel`` from C++ code.
-extern "C" void launchWindowKernel(dim3 gridDim,
-                                   dim3 blockDim,
-                                   uint64_t start_k,
+// Host-side wrapper used to launch ``windowKernel`` from C++ code.  The
+// implementation is provided in ``windowKernel.cu`` which is always compiled
+// with NVCC when ``BUILD_CUDA=1``.
+extern "C" void launchWindowKernel(uint64_t start_k,
                                    uint64_t range_len,
                                    uint32_t ws,
                                    const uint32_t *offsets,

--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -1,23 +1,27 @@
 CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
 
+.RECIPEPREFIX := ;
+
 all:
 ifeq ($(BUILD_CUDA), 1)
-	${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
-	mkdir -p $(BINDIR)
-	cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
+;# Compile and link using NVCC so that ``PollardEngine.cpp`` and the CUDA
+;# kernels are built with the proper toolchain.
+;${NVCC} -x cu -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
+;mkdir -p $(BINDIR)
+;cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif
 ifeq ($(BUILD_OPENCL),1)
-	${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
-	mkdir -p $(BINDIR)
-	cp clKeyFinder.bin $(BINDIR)/clBitCrack
+;${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
+;mkdir -p $(BINDIR)
+;cp clKeyFinder.bin $(BINDIR)/clBitCrack
 endif
 ifeq ($(CPU),1)
-	${CXX} -o KeyFinder.bin ${CPPSRC} ${INCLUDE} ${CXXFLAGS} ${LIBS} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -llogger -lutil -lcmdparse -pthread
-	mkdir -p $(BINDIR)
-	cp KeyFinder.bin $(BINDIR)/BitCrack
+;${CXX} -o KeyFinder.bin ${CPPSRC} ${INCLUDE} ${CXXFLAGS} ${LIBS} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -llogger -lutil -lcmdparse -pthread
+;mkdir -p $(BINDIR)
+;cp KeyFinder.bin $(BINDIR)/BitCrack
 endif
 
 clean:
-	rm -rf cuKeyFinder.bin
-	rm -rf clKeyFinder.bin
-	rm -rf KeyFinder.bin
+;rm -rf cuKeyFinder.bin
+;rm -rf clKeyFinder.bin
+;rm -rf KeyFinder.bin

--- a/KeyFinder/PollardEngine.cpp
+++ b/KeyFinder/PollardEngine.cpp
@@ -623,14 +623,11 @@ void PollardEngine::enumerateCandidates(const uint256 &k0, const uint256 &modulu
         CUDA_CHECK(cudaMemcpy(dev_target_frags, hostFrags.data(), offsetCount * sizeof(uint32_t), cudaMemcpyHostToDevice));
         CUDA_CHECK(cudaMemset(dev_count, 0, sizeof(uint32_t)));
 
-        // Launch the GPU kernel.
-        dim3 block(256);
-        dim3 grid((range_len + block.x - 1) / block.x);
-        launchWindowKernel(grid, block, start_k, range_len, ws,
+        // Launch the GPU kernel. ``launchWindowKernel`` performs its own error
+        // checking and device synchronisation.
+        launchWindowKernel(start_k, range_len, ws,
                            dev_offsets, offsetCount, mask,
                            dev_target_frags, dev_out, dev_count);
-        CUDA_CHECK(cudaGetLastError());
-        CUDA_CHECK(cudaDeviceSynchronize());
 
         // Retrieve matches.
         uint32_t hitCount = 0;

--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -12,6 +12,10 @@
 #include "KeySearchDevice.h"
 #include "PollardTypes.h"  // basic Pollard structures
 #if BUILD_CUDA
+// Definitions for the lightweight GPU window kernel used to pre-filter
+// candidates.  The header is safe to include in non-CUDA compilation units
+// thanks to the stub ``dim3`` structure it defines when ``__CUDACC__`` is not
+// present.
 #include "windowKernel.h"
 #endif
 

--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -32,7 +32,7 @@ endif
 
 all: $(OBJS)
 ifeq ($(BUILD_CUDA),1)
-;${NVCC} ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH} -o pollardtests.bin ${CPPSRC} $(OBJS) ${LIBS} ${LIBS_LOCAL}
+;${NVCC} -x cu ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH} -o pollardtests.bin ${CPPSRC} $(OBJS) ${LIBS} ${LIBS_LOCAL}
 else
 ;${CXX} ${CXXFLAGS} ${INCLUDE} -o pollardtests.bin ${CPPSRC} $(OBJS) ${LIBS} ${LIBS_LOCAL}
 endif
@@ -44,7 +44,7 @@ cuda_scalar_one.o: cuda_scalar_one.cu
     -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
 
 PollardEngine.o: ../KeyFinder/PollardEngine.cpp
-;${NVCC} -c ../KeyFinder/PollardEngine.cpp -o PollardEngine.o ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) \
+;${NVCC} -x cu -c ../KeyFinder/PollardEngine.cpp -o PollardEngine.o ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) \
     ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
 
 clean:


### PR DESCRIPTION
## Summary
- decouple windowKernel interface from CUDA headers and provide host-friendly launch wrapper
- wire PollardEngine to the new windowKernel launcher and clarify error handling
- update CUDA build scripts to compile with NVCC using a recipe prefix

## Testing
- `make -C KeyFinder BUILD_CUDA=1 NVCC=nvcc` *(fails: nvcc: No such file or directory)*
- `make -C PollardTests BUILD_CUDA=1 NVCC=nvcc` *(fails: nvcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6892bcdb4294832ea52d6c295b96935e