### PR TITLE
Refactor GPU window matching

### DIFF
--- a/CudaKeySearchDevice/CudaPollardDevice.cpp
+++ b/CudaKeySearchDevice/CudaPollardDevice.cpp
@@ -5,7 +5,15 @@
 #include <unordered_set>
 #include <algorithm>
 #include <stdexcept>
+#include <cstdio>
 #include "windowKernel.h"
+
+#define CUDA_CHECK(call) do { \
+    cudaError_t err__ = (call); \
+    if(err__ != cudaSuccess) { \
+        fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__, cudaGetErrorString(err__)); \
+    } \
+} while(0)
 
 using namespace secp256k1;
 
@@ -81,8 +89,8 @@ void CudaPollardDevice::startTameWalk(const uint256 &start, uint64_t steps,
     // Determine launch configuration based on device capabilities
     cudaDeviceProp prop;
     int dev = 0;
-    cudaGetDevice(&dev);
-    cudaGetDeviceProperties(&prop, dev);
+    CUDA_CHECK(cudaGetDevice(&dev));
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, dev));
 
     unsigned int threadsPerBlock;
     if(_blockDim) {
@@ -220,8 +228,8 @@ void CudaPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
     // Determine launch configuration similar to tame walk
     cudaDeviceProp prop;
     int dev = 0;
-    cudaGetDevice(&dev);
-    cudaGetDeviceProperties(&prop, dev);
+    CUDA_CHECK(cudaGetDevice(&dev));
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, dev));
 
     unsigned int threadsPerBlock;
     if(_blockDim) {
@@ -400,20 +408,20 @@ void CudaPollardDevice::scanKeyRange(uint64_t start_k,
     MatchRecord *d_out = nullptr;
     uint32_t *d_count = nullptr;
 
-    cudaMalloc(&d_offsets, offsetsCount * sizeof(uint32_t));
-    cudaMalloc(&d_targets, offsetsCount * sizeof(uint32_t));
-    cudaMalloc(&d_out, sizeof(MatchRecord) * 1024);
-    cudaMalloc(&d_count, sizeof(uint32_t));
+    CUDA_CHECK(cudaMalloc(&d_offsets, offsetsCount * sizeof(uint32_t)));
+    CUDA_CHECK(cudaMalloc(&d_targets, offsetsCount * sizeof(uint32_t)));
+    CUDA_CHECK(cudaMalloc(&d_out, sizeof(MatchRecord) * 1024));
+    CUDA_CHECK(cudaMalloc(&d_count, sizeof(uint32_t)));
 
-    cudaMemcpy(d_offsets, _offsets.data(), offsetsCount * sizeof(uint32_t), cudaMemcpyHostToDevice);
+    CUDA_CHECK(cudaMemcpy(d_offsets, _offsets.data(), offsetsCount * sizeof(uint32_t), cudaMemcpyHostToDevice));
 
     std::vector<MatchRecord> hostOut(1024);
     std::unordered_set<uint32_t> seen;
 
     cudaDeviceProp prop;
     int dev = 0;
-    cudaGetDevice(&dev);
-    cudaGetDeviceProperties(&prop, dev);
+    CUDA_CHECK(cudaGetDevice(&dev));
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, dev));
 
     unsigned int blockSize;
     if(_blockDim) {
@@ -447,15 +455,17 @@ void CudaPollardDevice::scanKeyRange(uint64_t start_k,
         dim3 grid(gridSize);
 
         for(uint32_t t = 0; t < windowBits; ++t) {
-            cudaMemcpy(d_targets, targetFragments[t], offsetsCount * sizeof(uint32_t), cudaMemcpyHostToDevice);
-            cudaMemset(d_count, 0, sizeof(uint32_t));
+            CUDA_CHECK(cudaMemcpy(d_targets, targetFragments[t], offsetsCount * sizeof(uint32_t), cudaMemcpyHostToDevice));
+            CUDA_CHECK(cudaMemset(d_count, 0, sizeof(uint32_t)));
             launchWindowKernel(grid, block, chunkStart, range, windowBits,
                                d_offsets, offsetsCount, mask, d_targets, d_out, d_count);
+            CUDA_CHECK(cudaGetLastError());
+            CUDA_CHECK(cudaDeviceSynchronize());
 
             uint32_t hCount = 0;
-            cudaMemcpy(&hCount, d_count, sizeof(uint32_t), cudaMemcpyDeviceToHost);
+            CUDA_CHECK(cudaMemcpy(&hCount, d_count, sizeof(uint32_t), cudaMemcpyDeviceToHost));
             if(hCount > hostOut.size()) hCount = hostOut.size();
-            cudaMemcpy(hostOut.data(), d_out, hCount * sizeof(MatchRecord), cudaMemcpyDeviceToHost);
+            CUDA_CHECK(cudaMemcpy(hostOut.data(), d_out, hCount * sizeof(MatchRecord), cudaMemcpyDeviceToHost));
 
             for(uint32_t i = 0; i < hCount; ++i) {
                 const MatchRecord &r = hostOut[i];

--- a/CudaKeySearchDevice/windowKernel.cu
+++ b/CudaKeySearchDevice/windowKernel.cu
@@ -1,18 +1,8 @@
 #include <stdint.h>
 #include <cuda_runtime.h>
-#include <cstdio>
-#include <cstdlib>  // for getenv
 
 #include "secp256k1.cuh"
 #include "windowKernel.h"
-
-// Simple CUDA error checking macro used throughout this file.
-#define CUDA_CHECK(call) do { \
-    cudaError_t err = (call); \
-    if(err != cudaSuccess) { \
-        printf("CUDA error %s:%d: %s\n", __FILE__, __LINE__, cudaGetErrorString(err)); \
-    } \
-} while(0)
 
 // -- EC helper routines ------------------------------------------------------
 
@@ -217,7 +207,9 @@ extern "C" __global__ void windowKernel(uint64_t start_k,
     }
 }
 
-extern "C" void launchWindowKernel(uint64_t start_k,
+extern "C" void launchWindowKernel(dim3 grid,
+                                   dim3 block,
+                                   uint64_t start_k,
                                    uint64_t range_len,
                                    uint32_t ws,
                                    const uint32_t *offsets,
@@ -226,28 +218,8 @@ extern "C" void launchWindowKernel(uint64_t start_k,
                                    const uint32_t *target_frags,
                                    MatchRecord *out_buf,
                                    uint32_t *out_count) {
-    // Determine launch configuration.  Defaults can be overridden using the
-    // environment variables WINDOW_KERNEL_BLOCKS and WINDOW_KERNEL_THREADS to
-    // ease experimentation without recompilation.
-    unsigned int threads = 256; // default threads per block
-    if(const char *env = std::getenv("WINDOW_KERNEL_THREADS")) {
-        unsigned int val = static_cast<unsigned int>(std::strtoul(env, nullptr, 10));
-        if(val > 0) threads = val;
-    }
-    unsigned int blocks = (range_len + threads - 1) / threads;
-    if(const char *env = std::getenv("WINDOW_KERNEL_BLOCKS")) {
-        unsigned int val = static_cast<unsigned int>(std::strtoul(env, nullptr, 10));
-        if(val > 0) blocks = val;
-    }
-
-    dim3 blockDim(threads);
-    dim3 gridDim(blocks);
-
-    // Launch the kernel and check for launch/runtime errors.
-    windowKernel<<<gridDim, blockDim>>>(start_k, range_len, ws, offsets,
-                                        offsets_count, mask, target_frags,
-                                        out_buf, out_count);
-    CUDA_CHECK(cudaGetLastError());
-    CUDA_CHECK(cudaDeviceSynchronize());
+    windowKernel<<<grid, block>>>(start_k, range_len, ws, offsets,
+                                  offsets_count, mask, target_frags,
+                                  out_buf, out_count);
 }
 

--- a/CudaKeySearchDevice/windowKernel.h
+++ b/CudaKeySearchDevice/windowKernel.h
@@ -3,9 +3,6 @@
 
 #include <cstdint>
 
-// When this header is consumed by a non-CUDA translation unit the ``dim3``
-// type normally provided by ``cuda_runtime.h`` is absent.  Provide a minimal
-// substitute so callers can still compile without pulling in CUDA headers.
 #ifndef __CUDACC__
 struct dim3 {
     unsigned int x, y, z;
@@ -14,17 +11,15 @@ struct dim3 {
 };
 #endif
 
-// Minimal record emitted by ``windowKernel`` describing a matching window.
 struct MatchRecord {
-    uint32_t offset;   // bit offset of the window
-    uint32_t fragment; // extracted fragment of the x-coordinate
-    uint64_t k;        // scalar where the match occurred
+    uint32_t offset;
+    uint32_t fragment;
+    uint64_t k;
 };
 
-// Host-side wrapper used to launch ``windowKernel`` from C++ code.  The block
-// and grid dimensions are chosen internally but can be influenced through
-// environment variables; see ``windowKernel.cu`` for details.
-extern "C" void launchWindowKernel(uint64_t start_k,
+extern "C" void launchWindowKernel(dim3 grid,
+                                   dim3 block,
+                                   uint64_t start_k,
                                    uint64_t range_len,
                                    uint32_t ws,
                                    const uint32_t *offsets,

--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -1,9 +1,9 @@
-CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
-# CUDA kernels that must be linked directly into the executable when building
-# the CUDA variant.
-CUSRC=../CudaKeySearchDevice/windowKernel.cu \
+CPPSRC=ConfigFile.cpp DeviceManager.cpp main.cpp
+# Sources compiled with NVCC when BUILD_CUDA=1
+CU_SRC_CPP=PollardEngine.cpp
+CU_SRC_CU=../CudaKeySearchDevice/windowKernel.cu \
       ../CudaKeySearchDevice/CudaPollard.cu
-CUOBJ=$(CUSRC:.cu=.o)
+CUOBJ=$(CU_SRC_CPP:=.o) $(CU_SRC_CU:=.o)
 
 .RECIPEPREFIX := ;
 
@@ -11,7 +11,7 @@ all:
 ifeq ($(BUILD_CUDA), 1)
 ;# Compile CUDA kernels with NVCC.  ``-x cu`` ensures the files are
 ;# treated as CUDA sources even though they carry a ``.cu`` extension.
-;for file in $(CUSRC) ; do \
+;for file in $(CU_SRC_CPP) $(CU_SRC_CU) ; do \
 ;${NVCC} -x cu -c $$file -o $${file}.o ${NVCCFLAGS} \
 ;    -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I../cudaMath ; \
 ;done
@@ -19,7 +19,8 @@ ifeq ($(BUILD_CUDA), 1)
 ;    -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 \
 ;    ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 \
 ;    -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil \
-;    -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
+;    -lCudaKeySearchDevice ../CudaKeySearchDevice/cuda_libs.o \
+;    -lcudadevrt -lcudart -lcmdparse
 ;mkdir -p $(BINDIR)
 ;cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif

--- a/KeyFinder/PollardEngine.cpp
+++ b/KeyFinder/PollardEngine.cpp
@@ -5,6 +5,7 @@
 #include "windowKernel.h"
 #include <cuda_runtime.h>
 #include <cstdio>
+#include <cstdlib>
 #define CUDA_CHECK(call) do { \
     cudaError_t err__ = (call); \
     if (err__ != cudaSuccess) { \
@@ -614,6 +615,20 @@ void PollardEngine::enumerateCandidates(const uint256 &k0, const uint256 &modulu
     CUDA_CHECK(cudaMalloc(&dev_count, sizeof(uint32_t)));
 
     CUDA_CHECK(cudaMemcpy(dev_offsets, _offsets.data(), offsetCount * sizeof(uint32_t), cudaMemcpyHostToDevice));
+
+    unsigned int threads = 256;
+    if(const char *env = std::getenv("WINDOW_KERNEL_THREADS")) {
+        unsigned int val = static_cast<unsigned int>(std::strtoul(env, nullptr, 10));
+        if(val > 0) threads = val;
+    }
+    unsigned int blocks = (range_len + threads - 1) / threads;
+    if(const char *env = std::getenv("WINDOW_KERNEL_BLOCKS")) {
+        unsigned int val = static_cast<unsigned int>(std::strtoul(env, nullptr, 10));
+        if(val > 0) blocks = val;
+    }
+    dim3 block(threads);
+    dim3 grid(blocks);
+
     for(size_t t = 0; t < _targets.size(); ++t) {
         // Pre-compute the target fragments for this hash.
         for(uint32_t i = 0; i < offsetCount; ++i) {
@@ -623,10 +638,7 @@ void PollardEngine::enumerateCandidates(const uint256 &k0, const uint256 &modulu
         CUDA_CHECK(cudaMemcpy(dev_target_frags, hostFrags.data(), offsetCount * sizeof(uint32_t), cudaMemcpyHostToDevice));
         CUDA_CHECK(cudaMemset(dev_count, 0, sizeof(uint32_t)));
 
-        // Launch the GPU kernel to perform the window/fragment matching.  The
-        // kernel configuration can be adjusted at runtime via environment
-        // variables (see ``windowKernel.cu``).
-        launchWindowKernel(start_k, range_len, ws,
+        launchWindowKernel(grid, block, start_k, range_len, ws,
                            dev_offsets, offsetCount, mask,
                            dev_target_frags, dev_out, dev_count);
         CUDA_CHECK(cudaGetLastError());
@@ -643,18 +655,20 @@ void PollardEngine::enumerateCandidates(const uint256 &k0, const uint256 &modulu
                        hitCount * sizeof(MatchRecord), cudaMemcpyDeviceToHost));
         }
 
-        // Convert GPU match records into CRT constraints.  The full private key
-        // candidates are validated later by ``processWindow`` which performs the
-        // CRT merge followed by hash160 verification.
+        std::vector<Constraint> constraints;
+        std::vector<unsigned int> offs;
         for(const auto &rec : hostBuf) {
             uint256 priv(rec.k);
             if(priv.cmp(L) < 0 || priv.cmp(U) > 0) {
-                continue; // discard matches outside the search interval
+                continue;
             }
             uint32_t mod32 = 1u << (rec.offset + ws);
             uint32_t rem32 = (rec.fragment << rec.offset) & (mod32 - 1u);
-            Constraint c{ uint256(mod32), uint256(rem32) };
-            processWindow(t, rec.offset, c);
+            constraints.emplace_back(uint256(mod32), uint256(rem32));
+            offs.push_back(rec.offset);
+        }
+        for(size_t i = 0; i < constraints.size(); ++i) {
+            processWindow(t, offs[i], constraints[i]);
         }
     }
 

--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -21,7 +21,7 @@ CUSRC=../CudaKeySearchDevice/windowKernel.cu \
 
 OBJS=
 ifeq ($(BUILD_CUDA),1)
-OBJS+=cuda_scalar_one.o PollardEngine.o $(CUSRC:.cu=.o)
+OBJS+=cuda_scalar_one.o PollardEngine.o CudaPollardDevice.o $(CUSRC:.cu=.o) ../CudaKeySearchDevice/cuda_libs.o
 endif
 
 CXXFLAGS+=-DBUILD_CUDA=$(BUILD_CUDA) -DBUILD_OPENCL=$(BUILD_OPENCL)
@@ -51,10 +51,14 @@ PollardEngine.o: ../KeyFinder/PollardEngine.cpp
 ;${NVCC} -c ../KeyFinder/PollardEngine.cpp -o PollardEngine.o ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) \
     ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
 
+CudaPollardDevice.o: ../CudaKeySearchDevice/CudaPollardDevice.cpp
+;${NVCC} -c ../CudaKeySearchDevice/CudaPollardDevice.cpp -o CudaPollardDevice.o ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) \
+    ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
+
 $(CUSRC:.cu=.o): %.o: %.cu
 ;${NVCC} -x cu -c $< -o $@ ${NVCCFLAGS} \
     -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
 
 clean:
-;rm -f pollardtests.bin cuda_scalar_one.o PollardEngine.o $(CUSRC:.cu=.o)
+;rm -f pollardtests.bin cuda_scalar_one.o PollardEngine.o CudaPollardDevice.o $(CUSRC:.cu=.o) ../CudaKeySearchDevice/cuda_libs.o
 


### PR DESCRIPTION
## Summary
- Offload window fragment matching to a dedicated `windowKernel` CUDA kernel and expose `launchWindowKernel` with explicit grid/block configuration.
- Drive Pollard CPU/GPU integration through the new kernel, building CRT constraints on host and adding CUDA error checks.
- Update build system and tests to compile CUDA sources with NVCC and link required device runtime objects.

## Testing
- `BUILD_CUDA=0 BUILD_OPENCL=0 timeout 100 make test`


------
https://chatgpt.com/codex/tasks/task_e_6892c1f42b58832ebf4f72fc6247fb61