### PR TITLE
Refactor Pollard GPU window matching

### DIFF
--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -6,8 +6,8 @@
 #include "ripemd160.cuh" // RIPEMD160 finalisation
 #include "secp256k1.cuh" // EC point operations
 #include "ptx.cuh"       // byte order helpers
-// Note: the dedicated window matching kernel now lives in ``windowKernel.cu``.
-// This file only contains the Pollard walk implementations.
+// The standalone window matching kernel resides in ``windowKernel.cu``.  This
+// translation unit focuses solely on the Pollard walk implementations.
 
 __device__ void hashPublicKeyCompressed(const uint32_t*, uint32_t, uint32_t*);
 

--- a/CudaKeySearchDevice/windowKernel.cu
+++ b/CudaKeySearchDevice/windowKernel.cu
@@ -1,8 +1,6 @@
 #include <stdint.h>
 #include <cuda_runtime.h>
 #include <cstdio>
-#include <cstdlib>  // for getenv
-
 #include "secp256k1.cuh"
 #include "windowKernel.h"
 
@@ -183,6 +181,10 @@ extern "C" __global__ void windowKernel(uint64_t start_k,
     uint64_t tid = blockIdx.x * blockDim.x + threadIdx.x;
     uint64_t stride = gridDim.x * blockDim.x;
 
+    // ``ws`` is currently unused within the kernel body but kept in the
+    // signature for future extensions and to mirror the host launcher.
+    (void)ws;
+
     // Grid-stride loop over the scalar range.
     for(uint64_t idx = tid; idx < range_len; idx += stride) {
         uint64_t k = start_k + idx;
@@ -217,7 +219,9 @@ extern "C" __global__ void windowKernel(uint64_t start_k,
     }
 }
 
-extern "C" void launchWindowKernel(uint64_t start_k,
+extern "C" void launchWindowKernel(dim3 grid,
+                                   dim3 block,
+                                   uint64_t start_k,
                                    uint64_t range_len,
                                    uint32_t ws,
                                    const uint32_t *offsets,
@@ -226,27 +230,10 @@ extern "C" void launchWindowKernel(uint64_t start_k,
                                    const uint32_t *target_frags,
                                    MatchRecord *out_buf,
                                    uint32_t *out_count) {
-    // Determine launch configuration.  Defaults can be overridden using the
-    // environment variables WINDOW_KERNEL_BLOCKS and WINDOW_KERNEL_THREADS to
-    // ease experimentation without recompilation.
-    unsigned int threads = 256; // default threads per block
-    if(const char *env = std::getenv("WINDOW_KERNEL_THREADS")) {
-        unsigned int val = static_cast<unsigned int>(std::strtoul(env, nullptr, 10));
-        if(val > 0) threads = val;
-    }
-    unsigned int blocks = (range_len + threads - 1) / threads;
-    if(const char *env = std::getenv("WINDOW_KERNEL_BLOCKS")) {
-        unsigned int val = static_cast<unsigned int>(std::strtoul(env, nullptr, 10));
-        if(val > 0) blocks = val;
-    }
-
-    dim3 blockDim(threads);
-    dim3 gridDim(blocks);
-
     // Launch the kernel and check for launch/runtime errors.
-    windowKernel<<<gridDim, blockDim>>>(start_k, range_len, ws, offsets,
-                                        offsets_count, mask, target_frags,
-                                        out_buf, out_count);
+    windowKernel<<<grid, block>>>(start_k, range_len, ws, offsets,
+                                  offsets_count, mask, target_frags,
+                                  out_buf, out_count);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaDeviceSynchronize());
 }

--- a/CudaKeySearchDevice/windowKernel.h
+++ b/CudaKeySearchDevice/windowKernel.h
@@ -3,10 +3,12 @@
 
 #include <cstdint>
 
-// When this header is consumed by a non-CUDA translation unit the ``dim3``
-// type normally provided by ``cuda_runtime.h`` is absent.  Provide a minimal
-// substitute so callers can still compile without pulling in CUDA headers.
-#ifndef __CUDACC__
+#ifdef __CUDACC__
+#include <cuda_runtime.h>
+#else
+// When compiled without CUDA support the ``dim3`` type provided by
+// ``cuda_runtime.h`` is unavailable.  Supply a lightweight substitute so the
+// launcher prototype below remains valid in host-only builds.
 struct dim3 {
     unsigned int x, y, z;
     dim3(unsigned int a = 1u, unsigned int b = 1u, unsigned int c = 1u)
@@ -21,10 +23,10 @@ struct MatchRecord {
     uint64_t k;        // scalar where the match occurred
 };
 
-// Host-side wrapper used to launch ``windowKernel`` from C++ code.  The block
-// and grid dimensions are chosen internally but can be influenced through
-// environment variables; see ``windowKernel.cu`` for details.
-extern "C" void launchWindowKernel(uint64_t start_k,
+// Host-side wrapper used to launch ``windowKernel`` from C++ code.
+extern "C" void launchWindowKernel(dim3 grid,
+                                   dim3 block,
+                                   uint64_t start_k,
                                    uint64_t range_len,
                                    uint32_t ws,
                                    const uint32_t *offsets,

--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -1,9 +1,10 @@
-CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
-# CUDA kernels that must be linked directly into the executable when building
-# the CUDA variant.
-CUSRC=../CudaKeySearchDevice/windowKernel.cu \
+CPPSRC=ConfigFile.cpp DeviceManager.cpp main.cpp
+# Sources compiled with NVCC when BUILD_CUDA=1 (``-x cu`` handles both .cu and
+# .cpp files in this list)
+CUSRC=PollardEngine.cpp \
+      ../CudaKeySearchDevice/windowKernel.cu \
       ../CudaKeySearchDevice/CudaPollard.cu
-CUOBJ=$(CUSRC:.cu=.o)
+CUOBJ=$(patsubst %.cpp,%.o,$(patsubst %.cu,%.o,$(CUSRC)))
 
 .RECIPEPREFIX := ;
 
@@ -12,7 +13,7 @@ ifeq ($(BUILD_CUDA), 1)
 ;# Compile CUDA kernels with NVCC.  ``-x cu`` ensures the files are
 ;# treated as CUDA sources even though they carry a ``.cu`` extension.
 ;for file in $(CUSRC) ; do \
-;${NVCC} -x cu -c $$file -o $${file}.o ${NVCCFLAGS} \
+;${NVCC} -x cu -c $$file -o $(patsubst %.cpp,%.o,$(patsubst %.cu,%.o,$$file)) ${NVCCFLAGS} \
 ;    -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I../cudaMath ; \
 ;done
 ;${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} $(CUOBJ) ${INCLUDE} \

--- a/KeyFinder/PollardEngine.cpp
+++ b/KeyFinder/PollardEngine.cpp
@@ -2,8 +2,8 @@
 #include "secp256k1.h"
 #include "AddressUtil.h"
 #if BUILD_CUDA
-#include "windowKernel.h"
 #include <cuda_runtime.h>
+#include "windowKernel.h"
 #include <cstdio>
 #define CUDA_CHECK(call) do { \
     cudaError_t err__ = (call); \
@@ -623,10 +623,10 @@ void PollardEngine::enumerateCandidates(const uint256 &k0, const uint256 &modulu
         CUDA_CHECK(cudaMemcpy(dev_target_frags, hostFrags.data(), offsetCount * sizeof(uint32_t), cudaMemcpyHostToDevice));
         CUDA_CHECK(cudaMemset(dev_count, 0, sizeof(uint32_t)));
 
-        // Launch the GPU kernel to perform the window/fragment matching.  The
-        // kernel configuration can be adjusted at runtime via environment
-        // variables (see ``windowKernel.cu``).
-        launchWindowKernel(start_k, range_len, ws,
+        // Launch the GPU kernel to perform the window/fragment matching.
+        dim3 block(256);
+        dim3 grid((range_len + block.x - 1) / block.x);
+        launchWindowKernel(grid, block, start_k, range_len, ws,
                            dev_offsets, offsetCount, mask,
                            dev_target_frags, dev_out, dev_count);
         CUDA_CHECK(cudaGetLastError());

--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -12,6 +12,8 @@
 #include "KeySearchDevice.h"
 #include "PollardTypes.h"  // basic Pollard structures
 #if BUILD_CUDA
+// ``windowKernel.h`` provides the MatchRecord structure and a host-side
+// launcher used when offloading window matching to CUDA.
 #include "windowKernel.h"
 #endif
 

--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -6,9 +6,6 @@ ifeq ($(strip $(BUILD_OPENCL)),)
 BUILD_OPENCL=0
 endif
 CPPSRC=main.cpp
-ifeq ($(BUILD_CUDA),0)
-CPPSRC+=../KeyFinder/PollardEngine.cpp
-endif
 CUDASRC=cuda_scalar_one.cu
 BINDIR?=.
 
@@ -21,7 +18,7 @@ CUSRC=../CudaKeySearchDevice/windowKernel.cu \
 
 OBJS=
 ifeq ($(BUILD_CUDA),1)
-OBJS+=cuda_scalar_one.o PollardEngine.o $(CUSRC:.cu=.o)
+OBJS+=main.o PollardEngine.o CudaPollardDevice.o cuda_scalar_one.o $(CUSRC:.cu=.o)
 endif
 
 CXXFLAGS+=-DBUILD_CUDA=$(BUILD_CUDA) -DBUILD_OPENCL=$(BUILD_OPENCL)
@@ -36,7 +33,7 @@ endif
 
 all: $(OBJS)
 ifeq ($(BUILD_CUDA),1)
-;${NVCC} ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH} -o pollardtests.bin ${CPPSRC} $(OBJS) ${LIBS} ${LIBS_LOCAL}
+;${NVCC} ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH} -o pollardtests.bin $(OBJS) ${LIBS} ${LIBS_LOCAL}
 else
 ;${CXX} ${CXXFLAGS} ${INCLUDE} -o pollardtests.bin ${CPPSRC} $(OBJS) ${LIBS} ${LIBS_LOCAL}
 endif
@@ -47,8 +44,16 @@ cuda_scalar_one.o: cuda_scalar_one.cu
 ;${NVCC} -c cuda_scalar_one.cu -o cuda_scalar_one.o ${NVCCFLAGS} \
     -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
 
+main.o: main.cpp
+;${NVCC} -c main.cpp -o main.o ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) \
+    ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
+
 PollardEngine.o: ../KeyFinder/PollardEngine.cpp
 ;${NVCC} -c ../KeyFinder/PollardEngine.cpp -o PollardEngine.o ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) \
+    ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
+
+CudaPollardDevice.o: ../CudaKeySearchDevice/CudaPollardDevice.cpp
+;${NVCC} -c ../CudaKeySearchDevice/CudaPollardDevice.cpp -o CudaPollardDevice.o ${NVCCFLAGS} -DBUILD_CUDA=1 -DBUILD_OPENCL=$(BUILD_OPENCL) \
     ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
 
 $(CUSRC:.cu=.o): %.o: %.cu
@@ -56,5 +61,5 @@ $(CUSRC:.cu=.o): %.o: %.cu
     -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
 
 clean:
-;rm -f pollardtests.bin cuda_scalar_one.o PollardEngine.o $(CUSRC:.cu=.o)
+;rm -f pollardtests.bin cuda_scalar_one.o main.o PollardEngine.o CudaPollardDevice.o $(CUSRC:.cu=.o)
 


### PR DESCRIPTION
## Summary
- Offloaded Pollard "window + match" stage to a standalone CUDA kernel emitting compact MatchRecord structs.
- Integrated GPU window matching into `PollardEngine` and `CudaPollardDevice`, adding CUDA error handling and configurable launch sizes.
- Updated build scripts to compile CUDA sources, including `PollardEngine.cpp`, with NVCC and link necessary CUDA runtime libraries.
- Ensure CUDA headers are included before declaring `dim3` by conditionally including `<cuda_runtime.h>` in `windowKernel.h`.

## Testing
- `make -C KeyFinder BUILD_CUDA=1 NVCC=nvcc` *(fails: nvcc: not found)*
- `make -C PollardTests BUILD_CUDA=1 NVCC=nvcc` *(fails: nvcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6892c1f42b58832ebf4f72fc6247fb61