### PR TITLE
Refactor Pollard window kernel and host integration

### DIFF
--- a/CudaKeySearchDevice/CudaPollardDevice.cpp
+++ b/CudaKeySearchDevice/CudaPollardDevice.cpp
@@ -458,6 +458,8 @@ void CudaPollardDevice::scanKeyRange(uint64_t start_k,
             CUDA_CHECK(cudaMemset(d_count, 0, sizeof(uint32_t)));
             launchWindowKernel(grid, block, chunkStart, range, windowBits,
                                d_offsets, offsetsCount, mask, d_targets, d_out, d_count);
+            CUDA_CHECK(cudaGetLastError());
+            CUDA_CHECK(cudaDeviceSynchronize());
 
             uint32_t hCount = 0;
             CUDA_CHECK(cudaMemcpy(&hCount, d_count, sizeof(uint32_t), cudaMemcpyDeviceToHost));

--- a/CudaKeySearchDevice/windowKernel.cu
+++ b/CudaKeySearchDevice/windowKernel.cu
@@ -1,8 +1,7 @@
-#include <stdint.h>
+#include "windowKernel.h"
 #include <cuda_runtime.h>
 #include <cstdio>
 #include "secp256k1.cuh"
-#include "windowKernel.h"
 
 // Simple CUDA error checking macro used throughout this file.
 #define CUDA_CHECK(call) do { \

--- a/CudaKeySearchDevice/windowKernel.h
+++ b/CudaKeySearchDevice/windowKernel.h
@@ -3,14 +3,10 @@
 
 #include <cstdint>
 
-
-#ifdef BUILD_CUDA
-#include <cuda_runtime.h>
-#else
-// When compiled without CUDA support the ``dim3`` type provided by
-// ``cuda_runtime.h`` is unavailable. Supply a lightweight substitute so the
-
-// launcher prototype below remains valid in host-only builds.
+// ``cuda_runtime.h`` defines ``dim3`` when compiling with NVCC.  In host-only
+// builds the definition is absent so supply a minimal stand‑in to keep the API
+// consistent.
+#ifndef __CUDACC__
 struct dim3 {
     unsigned int x, y, z;
     dim3(unsigned int a = 1u, unsigned int b = 1u, unsigned int c = 1u)

--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -16,11 +16,13 @@ ifeq ($(BUILD_CUDA), 1)
 ;${NVCC} -x cu -c $$file -o $(patsubst %.cpp,%.o,$(patsubst %.cu,%.o,$$file)) ${NVCCFLAGS} \
 ;    -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I../cudaMath ; \
 ;done
-;${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} $(CUOBJ) ${INCLUDE} \
-;    -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 \
+;${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} $(CUOBJ) \
+;    ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} \
+;    -gencode=arch=compute_89,code=sm_89 \
 ;    ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 \
 ;    -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil \
-;    -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
+;    -lCudaKeySearchDevice ../CudaKeySearchDevice/cuda_libs.o \
+;    -lcudadevrt -lcudart -lcmdparse
 ;mkdir -p $(BINDIR)
 ;cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif

--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -59,7 +59,9 @@ public:
                   unsigned int batchSize = 1024,
                   unsigned int pollInterval = 100,
                   bool sequential = false,
-                  bool debug = false);
+                  bool debug = false,
+                  unsigned int gridDim = 0,
+                  unsigned int blockDim = 256);
 
     // Add a constraint of the form k \equiv value (mod ``modulus``) for ``target``
     void addConstraint(size_t target, const secp256k1::uint256 &modulus,
@@ -117,6 +119,8 @@ private:
     secp256k1::uint256 _U;                    // search upper bound
     bool _sequential;                         // sequential walk mode
     bool _debug;                              // enable verbose logging
+    unsigned int _gridDim;                   // launch grid for window kernel
+    unsigned int _blockDim;                  // block size for window kernel
 
     // Metrics
     uint64_t _windowsProcessed = 0;           // number of windows consumed

--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -18,7 +18,8 @@ CUSRC=../CudaKeySearchDevice/windowKernel.cu \
 
 OBJS=
 ifeq ($(BUILD_CUDA),1)
-OBJS+=main.o PollardEngine.o CudaPollardDevice.o cuda_scalar_one.o $(CUSRC:.cu=.o)
+OBJS+=main.o PollardEngine.o CudaPollardDevice.o cuda_scalar_one.o \
+     $(CUSRC:.cu=.o) ../CudaKeySearchDevice/cuda_libs.o
 endif
 
 CXXFLAGS+=-DBUILD_CUDA=$(BUILD_CUDA) -DBUILD_OPENCL=$(BUILD_OPENCL)


### PR DESCRIPTION
## Summary
- Guard custom dim3 and add MatchRecord/launcher declarations in windowKernel.h
- Allow PollardEngine to configure kernel launch sizes and invoke standalone window kernel
- Link CUDA device objects for KeyFinder and PollardTests builds

## Testing
- `make BUILD_CUDA=1` *(fails: cuda.h: No such file or directory)*
- `apt-get update` *(fails: repository not signed)*
- `cd PollardTests && make BUILD_CUDA=1` *(fails: No rule to make target '../CudaKeySearchDevice/cuda_libs.o')*

------
https://chatgpt.com/codex/tasks/task_e_6892dfea193c832ea3f510e752d44d09