### PR TITLE
Refactor Pollard GPU window search

### DIFF
--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -325,68 +325,6 @@ __device__ static inline void point_mul_G(const uint32_t k[8], uint32_t X[8], ui
     scalarMultiplyBase(k, X, Y);
 }
 
-extern "C" __global__ void windowKernel(uint64_t start_k,
-                                         uint64_t range_length,
-                                         uint32_t ws,
-                                         const uint32_t *offsets,
-                                         uint32_t offsets_count,
-                                         uint32_t mask,
-                                         const uint32_t target_fragments[][MAX_OFFSETS],
-                                         MatchRecord *out_buffer,
-                                         uint32_t *out_count)
-{
-    uint64_t tid = blockIdx.x * blockDim.x + threadIdx.x;
-    uint64_t stride = gridDim.x * blockDim.x;
-
-    for(uint64_t idx = tid; idx < range_length; idx += stride) {
-        uint64_t k = start_k + idx;
-        uint32_t scalar[8] = {0};
-        scalar[0] = (uint32_t)(k & 0xffffffffULL);
-        scalar[1] = (uint32_t)(k >> 32);
-        uint32_t X[8];
-        uint32_t Y[8];
-        point_mul_G(scalar, X, Y);
-
-        for(uint32_t i = 0; i < offsets_count; ++i) {
-            uint32_t off = offsets[i];
-            uint32_t word = off >> 5;
-            uint32_t bit  = off & 31U;
-            uint64_t val = ((uint64_t)X[word]) >> bit;
-            if(bit && word < 7) {
-                val |= ((uint64_t)X[word + 1]) << (32 - bit);
-            }
-            uint32_t frag = (uint32_t)val & mask;
-            for(uint32_t t = 0; t < ws; ++t) {
-                if(frag == target_fragments[t][i]) {
-                    uint32_t outIdx = atomicAdd(out_count, 1u);
-                    out_buffer[outIdx].offset = off;
-                    out_buffer[outIdx].fragment = frag;
-                    out_buffer[outIdx].k = k;
-                }
-            }
-        }
-    }
-}
-
-extern "C" void launchWindowKernel(dim3 gridDim,
-                                    dim3 blockDim,
-                                    uint64_t start_k,
-                                    uint64_t range_length,
-                                    uint32_t ws,
-                                    const uint32_t *offsets,
-                                    uint32_t offsets_count,
-                                    uint32_t mask,
-                                    const uint32_t target_fragments[][MAX_OFFSETS],
-                                    MatchRecord *out_buffer,
-                                    uint32_t *out_count)
-{
-    windowKernel<<<gridDim, blockDim>>>(start_k, range_length, ws, offsets,
-                                        offsets_count, mask, target_fragments,
-                                        out_buffer, out_count);
-    CUDA_CHECK(cudaGetLastError());
-    CUDA_CHECK(cudaDeviceSynchronize());
-}
-
 // Legacy kernel retained for backwards compatibility. It performs a
 // random walk and records distinguished points (those where the low
 // ``windowBits`` bits of the scalar are zero), outputting the scalar and

--- a/CudaKeySearchDevice/CudaPollardDevice.h
+++ b/CudaKeySearchDevice/CudaPollardDevice.h
@@ -46,7 +46,7 @@ public:
     void scanKeyRange(uint64_t start_k,
                       uint64_t end_k,
                       uint32_t windowBits,
-                      const uint32_t targetFragments[][MAX_OFFSETS],
+                      const uint32_t *targetFragments,
                       std::vector<PollardEngine::Constraint> &outConstraints);
 };
 

--- a/CudaKeySearchDevice/windowKernel.h
+++ b/CudaKeySearchDevice/windowKernel.h
@@ -2,17 +2,39 @@
 #define WINDOW_KERNEL_H
 
 #include <cstdint>
-#include "../KeyFinder/PollardTypes.h"
 
-#ifdef __CUDACC__
-extern "C" __global__ void windowKernel(uint64_t start_k,
-                                         uint64_t range_len,
-                                         int ws,
-                                         const uint32_t *offsets,
-                                         uint32_t mask,
-                                         const uint32_t *target_frags,
-                                         MatchRecord *out_buf,
-                                         unsigned int *out_count);
+// Minimal record describing a fragment match for ``k``.  Each entry records
+// the bit ``offset`` within the x-coordinate, the extracted ``fragment`` and
+// the corresponding scalar ``k`` where the fragment was observed.
+struct MatchRecord {
+    uint32_t offset;
+    uint32_t fragment;
+    uint64_t k;
+};
+
+// When compiling without NVCC we still need a definition of ``dim3`` so that
+// host code including this header can declare grid and block dimensions.  NVCC
+// provides a proper definition via <cuda_runtime.h>.
+#ifndef __CUDACC__
+struct dim3 {
+    unsigned int x, y, z;
+    dim3(unsigned int vx = 1, unsigned int vy = 1, unsigned int vz = 1)
+        : x(vx), y(vy), z(vz) {}
+};
 #endif
+
+// Host-side wrapper used to launch ``windowKernel``.  ``gridDim`` and
+// ``blockDim`` allow callers to customise the launch configuration.
+extern "C" void launchWindowKernel(uint64_t start_k,
+                                   uint64_t range_len,
+                                   uint32_t ws,
+                                   const uint32_t *offsets,
+                                   uint32_t offsets_count,
+                                   uint32_t mask,
+                                   const uint32_t *target_frags,
+                                   MatchRecord *out_buf,
+                                   uint32_t *out_count,
+                                   dim3 gridDim,
+                                   dim3 blockDim);
 
 #endif // WINDOW_KERNEL_H

--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -10,7 +10,7 @@
 #include <chrono>
 #include "secp256k1.h"
 #include "KeySearchDevice.h"
-#include "PollardTypes.h"  // for MatchRecord
+#include "PollardTypes.h"
 #if BUILD_CUDA
 #include "../CudaKeySearchDevice/windowKernel.h"
 #endif
@@ -116,13 +116,6 @@ private:
     bool _sequential;                         // sequential walk mode
     bool _debug;                              // enable verbose logging
 
-#if BUILD_CUDA
-    // GPU buffers for window kernel results
-    uint32_t *_d_offsets = nullptr;
-    uint32_t *_d_frags = nullptr;
-    MatchRecord *_d_out = nullptr;
-    unsigned int *_d_count = nullptr;
-#endif
 
     // Metrics
     uint64_t _windowsProcessed = 0;           // number of windows consumed

--- a/KeyFinder/PollardTypes.h
+++ b/KeyFinder/PollardTypes.h
@@ -28,12 +28,4 @@ struct PollardWindow {
     secp256k1::uint256 scalarFragment;       // full scalar at the match
 };
 
-// Compact record emitted by ``windowKernel`` during key range scans. Each
-// entry captures the window offset, the extracted fragment of the x-coordinate
-// and the corresponding scalar ``k`` where the match occurred.
-struct MatchRecord {
-    uint32_t offset;   // bit offset within the x-coordinate
-    uint32_t fragment; // extracted window fragment
-    uint64_t k;        // scalar at the match
-};
 #endif

--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -22,11 +22,15 @@ ifeq ($(BUILD_OPENCL),1)
 LIBS_LOCAL+=-lclutil -lutil -lOpenCL -L${OPENCL_LIB} -lCLKeySearchDevice
 endif
 ifeq ($(BUILD_CUDA),1)
-LIBS_LOCAL+=-lcudart -L${CUDA_LIB} -lCudaKeySearchDevice
+LIBS_LOCAL+=-L${CUDA_LIB} -lCudaKeySearchDevice -lcudadevrt -lcudart -lkeyfinder
 endif
 
 all: $(OBJS)
+ifeq ($(BUILD_CUDA),1)
+;${NVCC} -o pollardtests.bin ${CPPSRC} $(OBJS) ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${LIBS} ${LIBS_LOCAL}
+else
 ;${CXX} -o pollardtests.bin ${CPPSRC} $(OBJS) ${INCLUDE} ${CXXFLAGS} ${LIBS} ${LIBS_LOCAL}
+endif
 ;mkdir -p $(BINDIR)
 ;cp pollardtests.bin $(BINDIR)/pollardtests
 


### PR DESCRIPTION
## Summary
- Implement standalone CUDA `windowKernel` with match record emission and host wrapper
- Integrate kernel into Pollard engine and device; remove duplicate definition
- Update build scripts for NVCC compilation and CUDA runtime linking

## Testing
- `make BUILD_CUDA=1` *(fails: cudaUtil.cpp:4:10: fatal error: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6892ebb44480832eb04dfafc766f4199