### PR TITLE
Integrate GPU window kernel and CRT pipeline

### DIFF
--- a/CudaKeySearchDevice/windowKernel.h
+++ b/CudaKeySearchDevice/windowKernel.h
@@ -2,6 +2,9 @@
 #define WINDOW_KERNEL_H
 
 #include <cstdint>
+#ifdef __CUDACC__
+#include <cuda_runtime.h>
+#endif
 
 // Minimal record describing a fragment match for ``k``.  Each entry records
 // the bit ``offset`` within the x-coordinate, the extracted ``fragment`` and
@@ -18,23 +21,18 @@ struct MatchRecord {
 #ifndef __CUDACC__
 struct dim3 {
     unsigned int x, y, z;
-    dim3(unsigned int vx = 1, unsigned int vy = 1, unsigned int vz = 1)
-        : x(vx), y(vy), z(vz) {}
+    dim3(unsigned int a = 1, unsigned int b = 1, unsigned int c = 1)
+        : x(a), y(b), z(c) {}
 };
 #endif
 
-// Host-side wrapper used to launch ``windowKernel``.  ``gridDim`` and
-// ``blockDim`` allow callers to customise the launch configuration.
-extern "C" void launchWindowKernel(uint64_t start_k,
-                                   uint64_t range_len,
-                                   uint32_t ws,
-                                   const uint32_t *offsets,
-                                   uint32_t offsets_count,
-                                   uint32_t mask,
+// Host-side wrapper used to launch ``windowKernel``.
+extern "C" void launchWindowKernel(dim3 grid, dim3 block,
+                                   uint64_t start_k, uint64_t range_len,
+                                   uint32_t ws, const uint32_t *offsets,
+                                   uint32_t offsets_count, uint32_t mask,
                                    const uint32_t *target_frags,
                                    MatchRecord *out_buf,
-                                   uint32_t *out_count,
-                                   dim3 gridDim,
-                                   dim3 blockDim);
+                                   uint32_t *out_count);
 
 #endif // WINDOW_KERNEL_H

--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -2,9 +2,15 @@ CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
 
 all:
 ifeq ($(BUILD_CUDA), 1)
-	${NVCC} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
-	mkdir -p $(BINDIR)
-	cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
+${NVCC} -x cu -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} \
+../CudaKeySearchDevice/windowKernel.o \
+../CudaKeySearchDevice/CudaPollard.o \
+../CudaKeySearchDevice/CudaPollardDevice.o \
+${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} \
+-lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lcudautil -llogger -lutil \
+-lcudart -lcudadevrt -lcmdparse
+mkdir -p $(BINDIR)
+cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif
 ifeq ($(BUILD_OPENCL),1)
 	${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse

--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -1,5 +1,5 @@
 NAME=PollardTests
-CPPSRC=main.cpp ../KeyFinder/PollardEngine.cpp
+CPPSRC=main.cpp ../KeyFinder/PollardEngine.cpp ../CudaKeySearchDevice/CudaPollardDevice.cpp
 CUDASRC=cuda_scalar_one.cu
 BINDIR?=.
 
@@ -27,12 +27,15 @@ endif
 
 all: $(OBJS)
 ifeq ($(BUILD_CUDA),1)
-;${NVCC} -o pollardtests.bin ${CPPSRC} $(OBJS) ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${LIBS} ${LIBS_LOCAL}
+;${NVCC} -x cu -o pollardtests.bin ${CPPSRC} $(OBJS) ${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} ${LIBS_LOCAL}
 else
 ;${CXX} -o pollardtests.bin ${CPPSRC} $(OBJS) ${INCLUDE} ${CXXFLAGS} ${LIBS} ${LIBS_LOCAL}
 endif
 ;mkdir -p $(BINDIR)
 ;cp pollardtests.bin $(BINDIR)/pollardtests
+
+pollard-tests: all
+;$(BINDIR)/pollardtests
 
 cuda_scalar_one.o: cuda_scalar_one.cu
 ;${NVCC} -c cuda_scalar_one.cu -o cuda_scalar_one.o ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}


### PR DESCRIPTION
## Summary
- consolidate window kernel into dedicated module with host wrapper
- integrate GPU-based window scanning with Pollard engine and device
- update build system and CUDA tests for unified kernel API

## Testing
- `make pollard-tests BUILD_CUDA=1 CUDA_HOME=/usr`


------
https://chatgpt.com/codex/tasks/task_e_6892f4114b34832e82d969084d6692f1