### PR TITLE
Include cstdio for window kernel

### DIFF
--- a/CudaKeySearchDevice/windowKernel.cu
+++ b/CudaKeySearchDevice/windowKernel.cu
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <cuda_runtime.h>
+#include <cstdio>
 
 #include "secp256k1.cuh"
 #include "windowKernel.h"


### PR DESCRIPTION
## Summary
- include `<cstdio>` so `fprintf` and `stderr` are defined in `windowKernel.cu`

## Testing
- `make dir_cudaKeySearchDevice` *(fails: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689306a95c10832e841d97c60f0c1887