### PR TITLE
Guard CUDA usage behind BUILD_CUDA

### DIFF
--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -1,5 +1,8 @@
 NAME=PollardTests
-CPPSRC=main.cpp ../KeyFinder/PollardEngine.cpp ../CudaKeySearchDevice/CudaPollardDevice.cpp
+CPPSRC=main.cpp ../KeyFinder/PollardEngine.cpp
+ifeq ($(BUILD_CUDA),1)
+CPPSRC+= ../CudaKeySearchDevice/CudaPollardDevice.cpp
+endif
 CUDASRC=cuda_scalar_one.cu
 BINDIR?=.
 


### PR DESCRIPTION
## Summary
- Only include `cuda_runtime.h` and launch kernels when `BUILD_CUDA` is enabled
- Build Pollard tests with `CudaPollardDevice.cpp` only under CUDA

## Testing
- `make dir_pollardtests BUILD_CUDA=0 BUILD_OPENCL=0 CPU=1`


------
https://chatgpt.com/codex/tasks/task_e_6893099a3ae4832e8661c0f1f8147132