### PR TITLE
Cap Pollard walk output buffer to prevent excessive allocation

### DIFF
--- a/CLKeySearchDevice/CLPollardDevice.cpp
+++ b/CLKeySearchDevice/CLPollardDevice.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <iostream>
 #include <cstdint>
+#include <algorithm>
 #include "clContext.h"
 #include "clutil.h"
 
@@ -127,7 +128,7 @@ void runWalk(PollardEngine &engine,
     cl_kernel kernel = clCreateKernel(program, "pollard_walk", &err);
     clCall(err);
 
-    cl_uint maxOut = static_cast<cl_uint>(steps * global);
+    cl_uint maxOut = static_cast<cl_uint>(std::min<uint64_t>(1024u, steps));
 
     cl_mem d_out = clCreateBuffer(ctx.getContext(), CL_MEM_WRITE_ONLY, sizeof(PollardWindowCL) * maxOut, NULL, &err);
     cl_mem d_count = clCreateBuffer(ctx.getContext(), CL_MEM_READ_WRITE, sizeof(cl_uint), NULL, &err);


### PR DESCRIPTION
## Summary
- cap the OpenCL Pollard walk output buffer at 1024 entries to prevent huge allocations
- include `<algorithm>` for std::min usage

## Testing
- `make BUILD_OPENCL=1`
- `make BUILD_OPENCL=1 test` *(fails: undefined reference to runCLHashWindowLE)*
- `./bin/clBitCrack --pollard --hash160 000... --offsets 0 --tames 1 --wilds 1` *(fails: Error detecting devices: CL_UNKNOWN_ERROR)*


------
https://chatgpt.com/codex/tasks/task_e_68930cf75480832ea9b1e85072b42ffa