### PR TITLE
Cap CUDA Pollard output buffer to 1024

### DIFF
--- a/CudaKeySearchDevice/CudaPollardDevice.cpp
+++ b/CudaKeySearchDevice/CudaPollardDevice.cpp
@@ -160,7 +160,7 @@ void CudaPollardDevice::startTameWalk(const uint256 &start, uint64_t steps,
 
     GpuPollardWindow *d_out = nullptr;
     uint32_t *d_count = nullptr;
-    uint32_t maxOut = static_cast<uint32_t>(steps * totalThreads);
+    uint32_t maxOut = std::min<uint32_t>(1024, static_cast<uint32_t>(steps * totalThreads));
     cudaMalloc(&d_out, sizeof(GpuPollardWindow) * maxOut);
     cudaMalloc(&d_count, sizeof(uint32_t));
     cudaMemset(d_count, 0, sizeof(uint32_t));
@@ -329,7 +329,7 @@ void CudaPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
 
     GpuPollardWindow *d_out = nullptr;
     uint32_t *d_count = nullptr;
-    uint32_t maxOut = static_cast<uint32_t>(steps * totalThreads);
+    uint32_t maxOut = std::min<uint32_t>(1024, static_cast<uint32_t>(steps * totalThreads));
     cudaMalloc(&d_out, sizeof(GpuPollardWindow) * maxOut);
     cudaMalloc(&d_count, sizeof(uint32_t));
     cudaMemset(d_count, 0, sizeof(uint32_t));


### PR DESCRIPTION
## Summary
- Limit `CudaPollardDevice` output slots to a maximum of 1024 for both tame and wild walks
- Prevent excessive allocations by bounding per-kernel output capacity

## Testing
- `CUDA_HOME=/usr NVCC=/usr/bin/nvcc NVLINK=/usr/bin/nvlink make dir_cudaKeySearchDevice`
- `CUDA_HOME=/usr NVCC=/usr/bin/nvcc NVLINK=/usr/bin/nvlink make pollard-tests`
- `./bin/pollardtests`


------
https://chatgpt.com/codex/tasks/task_e_689312b99e94832e81a23b412446f2a8