### PR TITLE
Use tabs for commands in KeyFinder ifeq blocks

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -2,15 +2,15 @@ CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
 
 all:
 ifeq ($(BUILD_CUDA), 1)
-${NVCC} -x cu -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} \
-../CudaKeySearchDevice/windowKernel.o \
-../CudaKeySearchDevice/CudaPollard.o \
-../CudaKeySearchDevice/CudaPollardDevice.o \
-${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} \
--lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lcudautil -llogger -lutil \
--lcudart -lcudadevrt -lcmdparse
-mkdir -p $(BINDIR)
-cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
+	${NVCC} -x cu -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} \
+	../CudaKeySearchDevice/windowKernel.o \
+	../CudaKeySearchDevice/CudaPollard.o \
+	../CudaKeySearchDevice/CudaPollardDevice.o \
+	${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} \
+	-lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lcudautil -llogger -lutil \
+	-lcudart -lcudadevrt -lcmdparse
+	mkdir -p $(BINDIR)
+	cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif
 ifeq ($(BUILD_OPENCL),1)
 	${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse


### PR DESCRIPTION
## Summary
- ensure commands inside KeyFinder's Makefile `ifeq` blocks use tab recipe prefixes

## Testing
- `make dir_keyfinder BUILD_CUDA=1 BUILD_OPENCL=0` *(fails: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68931c5147d8832e8f69080870b73b46