### PR TITLE
Refactor GPU window matching for Pollard Kangaroo

### DIFF
--- a/CudaKeySearchDevice/windowKernel.h
+++ b/CudaKeySearchDevice/windowKernel.h
@@ -1,38 +1,25 @@
+// SPDX-License-Identifier: MIT
 #ifndef WINDOW_KERNEL_H
 #define WINDOW_KERNEL_H
 
 #include <cstdint>
-#ifdef __CUDACC__
-#include <cuda_runtime.h>
-#endif
 
-// Minimal record describing a fragment match for ``k``.  Each entry records
-// the bit ``offset`` within the x-coordinate, the extracted ``fragment`` and
-// the corresponding scalar ``k`` where the fragment was observed.
-struct MatchRecord {
-    uint32_t offset;
-    uint32_t fragment;
-    uint64_t k;
-};
+// Simple POD describing a fragment match produced by ``windowKernel``.
+struct MatchRecord { uint32_t offset, fragment; uint64_t k; };
 
-// When compiling without NVCC we still need a definition of ``dim3`` so that
-// host code including this header can declare grid and block dimensions.  NVCC
-// provides a proper definition via <cuda_runtime.h>.
+// Provide a lightweight ``dim3`` definition for non-CUDA compilation units so
+// that host code can still declare grid dimensions when testing.
 #ifndef __CUDACC__
-struct dim3 {
-    unsigned int x, y, z;
-    dim3(unsigned int a = 1, unsigned int b = 1, unsigned int c = 1)
-        : x(a), y(b), z(c) {}
-};
+struct dim3 { unsigned int x, y, z; dim3(unsigned int a=1,unsigned int b=1,unsigned int c=1):x(a),y(b),z(c){} };
 #endif
 
-// Host-side wrapper used to launch ``windowKernel``.
-extern "C" void launchWindowKernel(dim3 grid, dim3 block,
-                                   uint64_t start_k, uint64_t range_len,
-                                   uint32_t ws, const uint32_t *offsets,
+// Host wrapper launching the GPU kernel. Grid configuration is chosen
+// internally; callers only specify the range and window parameters.
+extern "C" void launchWindowKernel(uint64_t start_k, uint64_t range_len,
+                                   uint32_t ws, const uint32_t* offsets,
                                    uint32_t offsets_count, uint32_t mask,
-                                   const uint32_t *target_frags,
-                                   MatchRecord *out_buf,
-                                   uint32_t *out_count);
+                                   const uint32_t* target_frags,
+                                   MatchRecord* out_buf,
+                                   uint32_t* out_count);
 
 #endif // WINDOW_KERNEL_H


### PR DESCRIPTION
## Summary
- Introduced standalone CUDA `windowKernel` with grid-stride loop for extracting and matching hash fragments on the GPU
- Simplified kernel launch API and header, providing auto-configured host launcher
- Integrated kernel into `PollardEngine` and `CudaPollardDevice` to build CRT constraints from GPU results

## Testing
- `make BUILD_CUDA=1 -j2` *(fails: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689320eb27cc832eb12fb8b60bdde1f0