### PR TITLE
Remove redundant point_mul_G wrappers

### DIFF
--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -321,10 +321,6 @@ __device__ static void scalarMultiplyBase(const unsigned int k[8], unsigned int 
     pointAdd(r1x, r1y, r2x, r2y, rx, ry);
 }
 
-__device__ static inline void point_mul_G(const uint32_t k[8], uint32_t X[8], uint32_t Y[8]) {
-    scalarMultiplyBase(k, X, Y);
-}
-
 // Legacy kernel retained for backwards compatibility. It performs a
 // random walk and records distinguished points (those where the low
 // ``windowBits`` bits of the scalar are zero), outputting the scalar and

--- a/CudaKeySearchDevice/windowKernel.cu
+++ b/CudaKeySearchDevice/windowKernel.cu
@@ -154,10 +154,6 @@ __device__ static void scalarMultiplyBase(const uint32_t k[8], uint32_t rx[8], u
     pointAdd(r1x, r1y, r2x, r2y, rx, ry);
 }
 
-__device__ static inline void point_mul_G(const uint32_t k[8], uint32_t X[8], uint32_t Y[8]) {
-    scalarMultiplyBase(k, X, Y);
-}
-
 // GPU kernel performing a grid-stride loop over scalars ``k`` and extracting
 // window fragments from the x-coordinate of ``k * G``. Matching fragments are
 // appended to ``out_buf`` using an atomic counter.
@@ -172,7 +168,7 @@ void windowKernel(uint64_t start_k, uint64_t range_len, uint32_t ws,
     for(uint64_t i = idx; i < range_len; i += stride) {
         uint64_t k = start_k + i;
         uint32_t X[8], Y[8];
-        point_mul_G(reinterpret_cast<const uint32_t*>(&k), X, Y);
+        scalarMultiplyBase(reinterpret_cast<const uint32_t*>(&k), X, Y);
         for(uint32_t j = 0; j < offsets_count; ++j) {
             uint32_t off  = offsets[j];
             uint32_t word = off >> 5;


### PR DESCRIPTION
## Summary
- drop unused `point_mul_G` helpers in CUDA code
- invoke `scalarMultiplyBase` directly for clarity

## Testing
- `make test`
- `make BUILD_CUDA=1 dir_cudaKeySearchDevice` *(fails: cudaUtil.h:4:10: fatal error: cuda.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68936abbbf40832e9872394ba54ddac8