### PR TITLE
Use explicit uint256 conversions for PollardEngine constraints

### DIFF
--- a/KeyFinder/PollardEngine.cpp
+++ b/KeyFinder/PollardEngine.cpp
@@ -609,7 +609,7 @@ void PollardEngine::enumerateCandidates(const uint256 &k0, const uint256 &modulu
             auto &r = hostBuf[i];
             uint32_t mod = 1u << (r.offset + _windowBits);
             uint32_t rem = (r.fragment << r.offset) & (mod - 1);
-            constraints.emplace_back(mod, rem);
+            constraints.push_back({secp256k1::uint256(mod), secp256k1::uint256(rem)});
         }
         for(uint32_t i = 0; i < hitCount; ++i) {
             processWindow(t, hostBuf[i].offset, constraints[i]);


### PR DESCRIPTION
## Summary
- use `secp256k1::uint256` to explicitly construct constraint modulus and remainder from `hostBuf`

## Testing
- `make BUILD_CUDA=1` *(fails: /usr/local/cuda-12.8/bin/nvcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_689397ee1560832e81021401ce734f63