### PR TITLE
Link CudaKeySearchDevice statically in KeyFinder build

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -3,11 +3,8 @@ CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
 all:
 ifeq ($(BUILD_CUDA), 1)
 	${NVCC} -x cu -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} \
-	../CudaKeySearchDevice/windowKernel.o \
-	../CudaKeySearchDevice/CudaPollard.o \
-	../CudaKeySearchDevice/CudaPollardDevice.o \
-	${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} \
-	-lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lcudautil -llogger -lutil \
+	${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} -L${LIBDIR} \
+	-lCudaKeySearchDevice -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lcudautil -llogger -lutil \
 	-lcudart -lcudadevrt -lcmdparse
 	mkdir -p $(BINDIR)
 	cp cuKeyFinder.bin $(BINDIR)/cuBitCrack


### PR DESCRIPTION
## Summary
- Streamline KeyFinder CUDA build to link against libCudaKeySearchDevice instead of individual object files
- Ensure library directory is on the link path and rely on nvcc device linking via -rdc=true

## Testing
- `CUDA_HOME=/usr/local/cuda make BUILD_CUDA=1 dir_keyfinder` *(fails: ptxas interrupted during build)*

------
https://chatgpt.com/codex/tasks/task_e_6893a9b1d450832e89825c0bdad30a39