### PR TITLE
Fix CUDA build object naming and includes

### DIFF
--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -12,12 +12,12 @@ cuda:
 ;rm -f ${CUDA_MATH}/sha256_constants.cu.o ${CUDA_MATH}/ripemd160_constants.cu.o cuda_libs.o
 ;for file in ${CPPSRC} ; do\
 ;   base=$${file%.*}; \
-;   ${NVCC} -x cu -c $$file -o "$${base}.o" ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE};\
+;   ${NVCC} -x cu -c $$file -o "$${base}.cpp.o" ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE};\
 ;done
 
 ;for file in ${CUSRC} ; do\
 ;   base=$${file%.*}; \
-;   ${NVCC} -c $$file -o "$${base}.o" ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
+;   ${NVCC} -c $$file -o "$${base}.cu.o" ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
 ;done
 
 ;for file in ${MATHSRC} ; do\
@@ -25,9 +25,9 @@ cuda:
 ;   ${NVCC} -c $$file -o ${CUDA_MATH}/$${file_name%.cu}.cu.o ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
 ;done
 
-;${NVCC} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 -dlink -o cuda_libs.o *.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o -lcudadevrt -lcudart
+;${NVCC} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 -dlink -o cuda_libs.o *.cpp.o *.cu.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o -lcudadevrt -lcudart
 
-;ar rvs ${LIBDIR}/lib$(NAME).a *.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o
+;ar rvs ${LIBDIR}/lib$(NAME).a *.cpp.o *.cu.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o
 
 clean:
 ;rm -f *.o

--- a/CudaKeySearchDevice/windowKernel.cu
+++ b/CudaKeySearchDevice/windowKernel.cu
@@ -1,6 +1,7 @@
 #include <stdint.h>
-#include <cuda_runtime.h>
 #include <cstdio>
+#include <cstdlib>
+#include <cuda_runtime.h>
 
 #include "secp256k1.cuh"
 #include "windowKernel.h"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CXXFLAGS=-O2 -std=c++11
 COMPUTE_CAP=89
 
 # Path to a specific CUDA toolkit installation
-CUDA_HOME ?= /usr/local/cuda-12.8
+CUDA_HOME ?= /usr/local/cuda
 CUDA_BIN=${CUDA_HOME}/bin
 
 # Explicitly reference compiler and linker from the same toolkit


### PR DESCRIPTION
## Summary
- default CUDA toolkit path to `/usr/local/cuda`
- prevent object file name collisions in CUDA device build
- add standard header includes for CUDA window kernel

## Testing
- `make BUILD_CUDA=1`
- `make pollard-tests`
- `./bin/pollardtests`


------
https://chatgpt.com/codex/tasks/task_e_68939d851454832e9afee919196f2fc3