### PR TITLE
Normalize CUDA object naming

### DIFF
--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -12,22 +12,18 @@ cuda:
 ;rm -f ${CUDA_MATH}/sha256_constants.cu.o ${CUDA_MATH}/ripemd160_constants.cu.o cuda_libs.o
 ;for file in ${CPPSRC} ; do\
 ;   base=$${file%.*}; \
-;   ${NVCC} -x cu -c $$file -o "$${base}.cpp.o" ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE};\
+;   ${NVCC} -x cu -c $$file -o $${base}.o ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE};\
 ;done
-
 ;for file in ${CUSRC} ; do\
 ;   base=$${file%.*}; \
-;   ${NVCC} -c $$file -o "$${base}.cu.o" ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
+;   ${NVCC} -c $$file -o $${base}.o ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
 ;done
-
 ;for file in ${MATHSRC} ; do\
 ;   file_name=$${file##*/}; \
 ;   ${NVCC} -c $$file -o ${CUDA_MATH}/$${file_name%.cu}.cu.o ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
 ;done
-
-;${NVCC} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 -dlink -o cuda_libs.o *.cpp.o *.cu.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o -lcudadevrt -lcudart
-
-;ar rvs ${LIBDIR}/lib$(NAME).a *.cpp.o *.cu.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o
+;${NVCC} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 -dlink -o cuda_libs.o *.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o -lcudadevrt -lcudart
+;objs=`ls *.o | grep -v cuda_libs.o`; ar rvs ${LIBDIR}/lib$(NAME).a $$objs ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o
 
 clean:
 ;rm -f *.o


### PR DESCRIPTION
## Summary
- Compile CUDA and C++ sources into `.o` files named after their base filename
- Re-archive these objects into `libCudaKeySearchDevice.a` so dependent modules resolve expected names

## Testing
- `make` *(fails: /bin/sh: 3: -x: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893f969a3a8832ea7b36008a83141a0