### PR TITLE
Honor BUILD_CUDA for Pollard tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ dir_clunittest: dir_clutil
 	make --directory CLUnitTests
 
 dir_pollardtests: dir_secp256k1lib dir_cryptoutil dir_util dir_addressutil dir_logger
-	make --directory PollardTests
+	$(MAKE) --directory PollardTests BUILD_CUDA=$(BUILD_CUDA)
 
 pollard-tests: dir_pollardtests
 

--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -8,8 +8,6 @@ BINDIR?=.
 
 BUILD_CUDA?=0
 BUILD_OPENCL?=0
-BUILD_CUDA:=$(if $(BUILD_CUDA),$(BUILD_CUDA),0)
-BUILD_OPENCL:=$(if $(BUILD_OPENCL),$(BUILD_OPENCL),0)
 
 .RECIPEPREFIX := ;
 
@@ -18,7 +16,8 @@ ifeq ($(BUILD_CUDA),1)
 OBJS+=cuda_scalar_one.o
 endif
 
-CXXFLAGS+=-DBUILD_CUDA=$(BUILD_CUDA) -DBUILD_OPENCL=$(BUILD_OPENCL)
+CXXFLAGS+=$(if $(BUILD_CUDA),-DBUILD_CUDA=1) $(if $(BUILD_OPENCL),-DBUILD_OPENCL=1)
+NVCCFLAGS+=$(if $(BUILD_CUDA),-DBUILD_CUDA=1) $(if $(BUILD_OPENCL),-DBUILD_OPENCL=1)
 
 LIBS_LOCAL=-laddressutil -lsecp256k1 -lcryptoutil -lutil -llogger
 ifeq ($(BUILD_OPENCL),1)
@@ -41,7 +40,7 @@ pollard-tests: all
 ;$(BINDIR)/pollardtests
 
 cuda_scalar_one.o: cuda_scalar_one.cu
-;${NVCC} -c cuda_scalar_one.cu -o cuda_scalar_one.o ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH}
+;${NVCC} -c cuda_scalar_one.cu -o cuda_scalar_one.o ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH} ${NVCCFLAGS}
 
 clean:
 ;rm -f pollardtests.bin cuda_scalar_one.o

--- a/PollardTests/main.cpp
+++ b/PollardTests/main.cpp
@@ -709,7 +709,10 @@ bool testGpuScalarOne() {
 
 #if BUILD_CUDA
     int cudaDevs = 0;
-    if(cudaGetDeviceCount(&cudaDevs) == cudaSuccess && cudaDevs > 0) {
+    cudaError_t cudaErr = cudaGetDeviceCount(&cudaDevs);
+    if(cudaErr != cudaSuccess) {
+        std::cout << "cudaGetDeviceCount error: " << cudaGetErrorString(cudaErr) << std::endl;
+    } else if(cudaDevs > 0) {
         ran = true;
         unsigned int x[8], y[8], h[5];
         if(!runCudaScalarOne(x, y, h)) return false;
@@ -870,7 +873,10 @@ bool testWindowCRT() {
     bool pass = true;
 #if BUILD_CUDA
     int devCount = 0;
-    if(cudaGetDeviceCount(&devCount) == cudaSuccess && devCount > 0) {
+    cudaError_t cudaErr2 = cudaGetDeviceCount(&devCount);
+    if(cudaErr2 != cudaSuccess) {
+        std::cout << "cudaGetDeviceCount error: " << cudaGetErrorString(cudaErr2) << std::endl;
+    } else if(devCount > 0) {
         ran = true;
         uint64_t L = 0, U = 1000;
         uint64_t key = 123;


### PR DESCRIPTION
## Summary
- propagate BUILD_CUDA to Pollard tests from the top-level Makefile
- conditionally define BUILD_CUDA for C++ and NVCC builds and reuse NVCCFLAGS for cuda_scalar_one
- log cudaGetDeviceCount errors so missing GPUs are distinguished from runtime failures

## Testing
- `make pollard-tests BUILD_CUDA=1`
- `bin/pollardtests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893feb0efb0832e955d05995c8c69b7