### PR TITLE
Align hash window logic with big-endian offsets

### DIFF
--- a/CLKeySearchDevice/CLPollardDevice.h
+++ b/CLKeySearchDevice/CLPollardDevice.h
@@ -23,6 +23,7 @@ public:
 
     static secp256k1::uint256 maskBits(unsigned int bits);
     static secp256k1::uint256 hashWindowLE(const unsigned int h[5], unsigned int offset, unsigned int bits);
+    static secp256k1::uint256 hashWindowBE(const unsigned int h[5], unsigned int offset, unsigned int bits);
 
     void startTameWalk(const secp256k1::uint256 &start, uint64_t steps,
                        const secp256k1::uint256 &seed, bool sequential) override;


### PR DESCRIPTION
## Summary
- switch hash window extraction to big-endian offsets and adapt GPU/CPU preprocessing
- align CRT constraint building with Python logic using big-endian offsets
- update tests and device wrappers for big-endian window handling

## Testing
- `make -C PollardTests BUILD_CUDA= BUILD_OPENCL= INCLUDE="-I.. -I../secp256k1lib -I../AddressUtil -I../KeyFinderLib -I../CudaKeySearchDevice -I../CLKeySearchDevice -I../CryptoUtil -I../Logger -I../util -I../KeyFinder"` *(fails: cannot find -laddressutil)*

------
https://chatgpt.com/codex/tasks/task_e_689404df0ac4832ea8b26ef2c6384e42