### PR TITLE
Fix pollard hash parity index

### DIFF
--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -388,7 +388,7 @@ extern "C" __global__ void pollardRandomWalk(CudaPollardMatch *out,
             unsigned int digest[5];
             unsigned int finalHashBE[5];
             unsigned int finalHash[5];
-            hashPublicKeyCompressed(px, py[7] & 1, digest);
+            hashPublicKeyCompressed(px, py[0] & 1, digest);
             doRMD160FinalRound(digest, finalHashBE);
             // Convert to little-endian word order
             for(int j = 0; j < 5; ++j) {
@@ -465,7 +465,7 @@ extern "C" __global__ void pollardWalk(GpuPollardWindow *out,
             uint32_t digest[5];
             uint32_t finalHashBE[5];
             uint32_t finalHash[5];
-            hashPublicKeyCompressed(px, py[7] & 1, digest);
+            hashPublicKeyCompressed(px, py[0] & 1, digest);
             doRMD160FinalRound(digest, finalHashBE);
             // Convert to little-endian word order
             for(int j = 0; j < 5; ++j) {
@@ -501,7 +501,7 @@ extern "C" __global__ void pollardWalk(GpuPollardWindow *out,
             uint32_t digest[5];
             uint32_t finalHashBE[5];
             uint32_t finalHash[5];
-            hashPublicKeyCompressed(px, py[7] & 1, digest);
+            hashPublicKeyCompressed(px, py[0] & 1, digest);
             doRMD160FinalRound(digest, finalHashBE);
             // Convert to little-endian word order
             for(int j = 0; j < 5; ++j) {


### PR DESCRIPTION
## Summary
- compute compressed public key hash parity from `py[0] & 1` instead of `py[7] & 1` in CUDA Pollard walk

## Testing
- `make BUILD_CUDA=1` *(failed: undefined reference to `CudaKeySearchDevice::CudaKeySearchDevice(int, int, int, int)`)*
- `make BUILD_CUDA=1 pollard-tests` *(failed: missing terminating `"` character in cuda_scalar_one.o)*

------
https://chatgpt.com/codex/tasks/task_e_68943066e8d0832e8e4eb7f32ac2303d