### PR TITLE
Normalize CudaKeySearchDevice object outputs

### DIFF
--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -3,6 +3,10 @@ CPPSRC:=$(wildcard *.cpp)
 CUSRC:=$(wildcard *.cu)
 MATHSRC:=$(CUDA_MATH)/sha256_constants.cu $(CUDA_MATH)/ripemd160_constants.cu
 
+CPPOBJS:=$(addsuffix .o,$(basename $(CPPSRC)))
+CUOBJS:=$(addsuffix .o,$(basename $(CUSRC)))
+OBJS:=$(CPPOBJS) $(CUOBJS)
+
 .RECIPEPREFIX := ;
 
 all:    cuda
@@ -11,19 +15,19 @@ cuda:
 ;rm -f *.o
 ;rm -f ${CUDA_MATH}/sha256_constants.cu.o ${CUDA_MATH}/ripemd160_constants.cu.o cuda_libs.o
 ;for file in ${CPPSRC} ; do\
-;   base=$${file%.*}; \
+;   base=$(basename $$file .cpp); \
 ;   ${NVCC} -x cu -c $$file -o $${base}.o ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE};\
 ;done
 ;for file in ${CUSRC} ; do\
-;   base=$${file%.*}; \
+;   base=$(basename $$file .cu); \
 ;   ${NVCC} -c $$file -o $${base}.o ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
 ;done
 ;for file in ${MATHSRC} ; do\
 ;   file_name=$${file##*/}; \
 ;   ${NVCC} -c $$file -o ${CUDA_MATH}/$${file_name%.cu}.cu.o ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
 ;done
-;${NVCC} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 -dlink -o cuda_libs.o *.o ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o -lcudadevrt -lcudart
-;objs=`ls *.o | grep -v cuda_libs.o`; ar rvs ${LIBDIR}/lib$(NAME).a $$objs ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o
+;${NVCC} ${NVCCFLAGS} -gencode=arch=compute_89,code=sm_89 -dlink -o cuda_libs.o ${OBJS} ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o -lcudadevrt -lcudart
+;ar rvs ${LIBDIR}/lib$(NAME).a ${OBJS} ../cudaMath/sha256_constants.cu.o ../cudaMath/ripemd160_constants.cu.o
 
 clean:
 ;rm -f *.o


### PR DESCRIPTION
## Summary
- ensure CudaKeySearchDevice compiles .cpp and .cu sources into normalized object names
- link library from normalized object list instead of wildcard

## Testing
- `make cuda` *(fails: /bin/sh: 3: -x: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68946b7309bc832ea39cff48525f7b0e