### PR TITLE
Link CudaKeySearchDevice via static library

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -3,7 +3,7 @@ CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
 all:
 ifeq ($(BUILD_CUDA), 1)
 	${NVCC} -x cu -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} \
-	${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} -L${LIBDIR} \
+	${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} -L${LIBDIR} -L../CudaKeySearchDevice \
 	-lCudaKeySearchDevice -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lcudautil -llogger -lutil \
 	-lcudart -lcudadevrt -lcmdparse
 	mkdir -p $(BINDIR)


### PR DESCRIPTION
## Summary
- Ensure KeyFinder links against the CudaKeySearchDevice static library instead of object files.

## Testing
- `make dir_keyfinder BUILD_CUDA=1` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68946fae7608832eb548a505808f762a