### PR TITLE
Handle hash offsets in little endian directly

### DIFF
--- a/KeyFinder/PollardEngine.h
+++ b/KeyFinder/PollardEngine.h
@@ -122,7 +122,7 @@ private:
 
     ResultCallback _callback;
     unsigned int _windowBits;                 // number of bits per window
-    std::vector<unsigned int> _offsets;       // bit offsets of each window
+    std::vector<unsigned int> _offsets;       // little-endian bit offsets of each window
     std::vector<TargetState> _targets;        // state per target hash
 
     std::unique_ptr<PollardDevice> _device;   // producer of walk results


### PR DESCRIPTION
## Summary
- convert configured offsets to little-endian positions once during setup
- use configured offsets directly in window matching and processing
- simplify GPU offset handling

## Testing
- `make -C PollardTests pollard-tests` *(fails: AddressUtil.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689525bd5e54832ea2ea11c0d126c8db