### PR TITLE
Add CUDA error wrapper and apply across host code

### DIFF
--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -9,13 +9,6 @@
 
 __device__ void hashPublicKeyCompressed(const uint32_t*, uint32_t, uint32_t*);
 
-#define CUDA_CHECK(call) do { \
-    cudaError_t err = (call); \
-    if(err != cudaSuccess) { \
-        fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__, cudaGetErrorString(err)); \
-    } \
-} while(0)
-
 // Result written by the kernel when a hash window matches a target.
 struct GpuPollardWindow {
     uint32_t targetIdx;

--- a/cudaUtil/cudaUtil.h
+++ b/cudaUtil/cudaUtil.h
@@ -9,11 +9,13 @@
 #include <string>
 #include <vector>
 
-#define CUDA_CHECK(call)                                                          \
+#define CUDA_CHECK(call)                                                         \
     do {                                                                         \
         cudaError_t err__ = (call);                                              \
         if (err__ != cudaSuccess) {                                              \
-            fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__,       \
+            fprintf(stderr,                                                     \
+                    "CUDA error at %s:%d (%s): %s\n",                            \
+                    __FILE__, __LINE__, #call,                                   \
                     cudaGetErrorString(err__));                                  \
             exit(1);                                                             \
         }                                                                        \


### PR DESCRIPTION
## Summary
- Define a reusable `CUDA_CHECK` macro for handling CUDA API errors
- Use `CUDA_CHECK` across pollard engine and CUDA pollard device host code
- Remove redundant local macro from `CudaPollard.cu`

## Testing
- `make pollard-tests` *(fails: fatal error: cuda_runtime.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68952ac97f50832ebcbdbdd0c619b82e