### PR TITLE
Ensure Pollard test builds include proper headers and CUDA runtime

### DIFF
--- a/PollardTests/Makefile
+++ b/PollardTests/Makefile
@@ -1,8 +1,5 @@
 NAME=PollardTests
 CPPSRC=main.cpp ../KeyFinder/PollardEngine.cpp
-ifeq ($(BUILD_CUDA),1)
-CPPSRC+= ../CudaKeySearchDevice/CudaPollardDevice.cpp
-endif
 ifeq ($(BUILD_OPENCL),1)
 CPPSRC+= ../CLKeySearchDevice/CLPollardDevice.cpp
 endif
@@ -12,6 +9,15 @@ BINDIR?=.
 BUILD_CUDA?=0
 BUILD_OPENCL?=0
 
+# Header include paths
+INCLUDE?=-I.. -I../util -I../AddressUtil -I../CryptoUtil -I../KeyFinderLib -I../KeyFinder -I../secp256k1lib -I../Logger
+ifeq ($(BUILD_CUDA),1)
+INCLUDE+=-I../cudaUtil -I../CudaKeySearchDevice -I../cudaMath
+endif
+ifeq ($(BUILD_OPENCL),1)
+INCLUDE+=-I../clUtil -I../CLKeySearchDevice -I../embedcl
+endif
+
 .RECIPEPREFIX := ;
 
 OBJS=
@@ -19,20 +25,20 @@ ifeq ($(BUILD_CUDA),1)
 OBJS+=cuda_scalar_one.o
 endif
 
-CXXFLAGS+=$(if $(BUILD_CUDA),-DBUILD_CUDA=1) $(if $(BUILD_OPENCL),-DBUILD_OPENCL=1)
-NVCCFLAGS+=$(if $(BUILD_CUDA),-DBUILD_CUDA=1) $(if $(BUILD_OPENCL),-DBUILD_OPENCL=1)
+CXXFLAGS+=$(if $(filter 1,$(BUILD_CUDA)),-DBUILD_CUDA=1) $(if $(filter 1,$(BUILD_OPENCL)),-DBUILD_OPENCL=1)
+NVCCFLAGS+=$(if $(filter 1,$(BUILD_CUDA)),-DBUILD_CUDA=1) $(if $(filter 1,$(BUILD_OPENCL)),-DBUILD_OPENCL=1)
 
 LIBS_LOCAL=-laddressutil -lsecp256k1 -lcryptoutil -lutil -llogger
 ifeq ($(BUILD_OPENCL),1)
 LIBS_LOCAL+=-lclutil -lutil -lOpenCL -L${OPENCL_LIB} -lCLKeySearchDevice
 endif
 ifeq ($(BUILD_CUDA),1)
-LIBS_LOCAL+=-L${CUDA_LIB} -lCudaKeySearchDevice -lcudart
+LIBS_LOCAL+=-L${CUDA_LIB} -lCudaKeySearchDevice -lcudadevrt -lcudart
 endif
 
 all: $(OBJS)
 ifeq ($(BUILD_CUDA),1)
-;${NVCC} -x cu -o pollardtests.bin ${CPPSRC} $(OBJS) ${INCLUDE} -I${CUDA_INCLUDE} $(if $(BUILD_OPENCL),-I${OPENCL_INCLUDE}) ${NVCCFLAGS} ${LIBS} ${LIBS_LOCAL}
+;${NVCC} -o pollardtests.bin ${CPPSRC} $(OBJS) ${INCLUDE} -I${CUDA_INCLUDE} $(if $(BUILD_OPENCL),-I${OPENCL_INCLUDE}) ${NVCCFLAGS} ${LIBS} ${LIBS_LOCAL}
 else
 ;${CXX} -o pollardtests.bin ${CPPSRC} $(OBJS) ${INCLUDE} $(if $(BUILD_OPENCL),-I${OPENCL_INCLUDE}) ${CXXFLAGS} ${LIBS} ${LIBS_LOCAL}
 endif


### PR DESCRIPTION
## Summary
- Set explicit header include paths for Pollard tests
- Link CUDA device runtime when building Pollard tests with CUDA
- Handle conditional CUDA/OpenCL flags more robustly

## Testing
- `make pollard-tests CPU=1`
- `make pollard-tests BUILD_CUDA=1` *(fails: reference to '_RIPEMD160_IV' in 'cuda_scalar_one.o')*
- `make pollard-tests BUILD_OPENCL=1` *(fails: cannot find -lclutil or -lCLKeySearchDevice)*


------
https://chatgpt.com/codex/tasks/task_e_68953513dc7c832e8d90edf8f5ed1dc4