### PR TITLE
Link cudadevrt and clean OpenCL linking

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -5,12 +5,12 @@ ifeq ($(BUILD_CUDA), 1)
 	${NVCC} -DBUILD_CUDA -std=c++11 -rdc=true -o cuKeyFinder.bin ${CPPSRC} ../CudaKeySearchDevice/windowKernel.o \
 	${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} -L${LIBDIR} -L../CudaKeySearchDevice \
 	-lCudaKeySearchDevice -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lcudautil -llogger -lutil \
-	-lcudart -lcmdparse
+	-lcudart -lcudadevrt -lcmdparse
 		mkdir -p $(BINDIR)
 		cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif
 ifeq ($(BUILD_OPENCL),1)
-		${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
+		${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} -L${LIBDIR} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
 		mkdir -p $(BINDIR)
 		cp clKeyFinder.bin $(BINDIR)/clBitCrack
 endif


### PR DESCRIPTION
## Summary
- Link CUDA device runtime (`-lcudadevrt`) in CUDA KeyFinder build
- Avoid linking CUDA libraries when building OpenCL KeyFinder

## Testing
- `make BUILD_CUDA=1 dir_keyfinder` *(fails: identifier `CUDA_CHECK` undefined)*
- `make BUILD_OPENCL=1 dir_keyfinder` *(fails: cannot find `-lcmdparse`)*

------
https://chatgpt.com/codex/tasks/task_e_68953cb59374832e9af31624fa7c21d2