### PR TITLE
Fix const correctness of uint256 toString

### DIFF
--- a/secp256k1lib/secp256k1.cpp
+++ b/secp256k1lib/secp256k1.cpp
@@ -613,9 +613,9 @@ uint256 secp256k1::multiplyModN(const uint256 &a, const uint256 &b)
 	return r;
 }
 
-std::string secp256k1::uint256::toString(int base)
+std::string secp256k1::uint256::toString(int base) const
 {
-	std::string s = "";
+        std::string s = "";
 
 	for(int i = 7; i >= 0; i--) {
 		char hex[9] = { 0 };

--- a/secp256k1lib/secp256k1.h
+++ b/secp256k1lib/secp256k1.h
@@ -271,12 +271,12 @@ namespace secp256k1 {
 			return (this->v[n / 32] & (0x1 << (n % 32))) != 0;
 		}
 
-		bool isEven()
-		{
-			return (this->v[0] & 1) == 0;
-		}
+                bool isEven() const
+                {
+                        return (this->v[0] & 1) == 0;
+                }
 
-		std::string toString(int base = 16);
+                std::string toString(int base = 16) const;
 
         uint64_t toUint64()
         {
@@ -330,18 +330,18 @@ namespace secp256k1 {
 			return this->x == p.x && this->y == p.y;
 		}
 
-		std::string toString(bool compressed = false)
-		{
-			if(!compressed) {
-				return "04" + this->x.toString() + this->y.toString();
-			} else {
-				if(this->y.isEven()) {
-					return "02" + this->x.toString();
-				} else {
-					return "03" + this->x.toString();
-				}
-			}
-		}
+                std::string toString(bool compressed = false) const
+                {
+                        if(!compressed) {
+                                return "04" + this->x.toString() + this->y.toString();
+                        } else {
+                                if(this->y.isEven()) {
+                                        return "02" + this->x.toString();
+                                } else {
+                                        return "03" + this->x.toString();
+                                }
+                        }
+                }
 	};
 
 	const uint256 P(_P_WORDS);


### PR DESCRIPTION
## Summary
- allow calling `secp256k1::uint256::toString` on const instances
- make `ecpoint::toString` and `isEven` const for consistency

## Testing
- `make pollard-tests CPU=1`
- `bin/pollardtests`


------
https://chatgpt.com/codex/tasks/task_e_68955b05d46c832e86783e3d9f1e7259