### PR TITLE
Fix Pollard test build by const-correcting uint256

### DIFF
--- a/secp256k1lib/secp256k1.cpp
+++ b/secp256k1lib/secp256k1.cpp
@@ -613,7 +613,7 @@ uint256 secp256k1::multiplyModN(const uint256 &a, const uint256 &b)
 	return r;
 }
 
-std::string secp256k1::uint256::toString(int base)
+std::string secp256k1::uint256::toString(int base) const
 {
 	std::string s = "";
 

--- a/secp256k1lib/secp256k1.h
+++ b/secp256k1lib/secp256k1.h
@@ -264,19 +264,19 @@ namespace secp256k1 {
 			return product;
 		}
 
-		bool bit(int n)
-		{
-			n = n % 256;
+                bool bit(int n) const
+                {
+                        n = n % 256;
 
-			return (this->v[n / 32] & (0x1 << (n % 32))) != 0;
-		}
+                        return (this->v[n / 32] & (0x1 << (n % 32))) != 0;
+                }
 
-		bool isEven()
-		{
-			return (this->v[0] & 1) == 0;
-		}
+                bool isEven() const
+                {
+                        return (this->v[0] & 1) == 0;
+                }
 
-		std::string toString(int base = 16);
+                std::string toString(int base = 16) const;
 
         uint64_t toUint64()
         {


### PR DESCRIPTION
## Summary
- make `secp256k1::uint256::toString`, `bit`, and `isEven` const for safer use on immutable values
- adjust uint256 string conversion definition accordingly

## Testing
- `make pollard-tests CPU=1`


------
https://chatgpt.com/codex/tasks/task_e_68955b05d46c832e86783e3d9f1e7259