### PR TITLE
Fix const-correctness of uint256::toString

### DIFF
--- a/secp256k1lib/secp256k1.cpp
+++ b/secp256k1lib/secp256k1.cpp
@@ -613,7 +613,7 @@ uint256 secp256k1::multiplyModN(const uint256 &a, const uint256 &b)
 	return r;
 }
 
-std::string secp256k1::uint256::toString(int base)
+std::string secp256k1::uint256::toString(int base) const
 {
 	std::string s = "";
 

--- a/secp256k1lib/secp256k1.h
+++ b/secp256k1lib/secp256k1.h
@@ -276,7 +276,7 @@ namespace secp256k1 {
 			return (this->v[0] & 1) == 0;
 		}
 
-		std::string toString(int base = 16);
+               std::string toString(int base = 16) const;
 
         uint64_t toUint64()
         {


### PR DESCRIPTION
## Summary
- Make `uint256::toString` const so it can be called on const objects

## Testing
- `make pollard-tests BUILD_CUDA=1` *(fails: nvlink undefined references)*

------
https://chatgpt.com/codex/tasks/task_e_68955b05d46c832e86783e3d9f1e7259