### PR TITLE
Add offset basis controls and CRT debug logging

### DIFF
--- a/CLKeySearchDevice/CLPollardDevice.h
+++ b/CLKeySearchDevice/CLPollardDevice.h
@@ -29,7 +29,7 @@ public:
                        const secp256k1::uint256 &seed, bool sequential) override;
     void startWildWalk(const secp256k1::uint256 &start, uint64_t steps,
                        const secp256k1::uint256 &seed, bool sequential) override;
-    bool popResult(PollardMatch &out) override { (void)out; return false; }
+    bool popResult(PollardWindow &out) override { (void)out; return false; }
 };
 
 #endif

--- a/CudaKeySearchDevice/CudaPollardDevice.h
+++ b/CudaKeySearchDevice/CudaPollardDevice.h
@@ -31,7 +31,7 @@ public:
                        const secp256k1::uint256 &seed, bool sequential) override;
     void startWildWalk(const secp256k1::uint256 &start, uint64_t steps,
                        const secp256k1::uint256 &seed, bool sequential) override;
-    bool popResult(PollardMatch &out) override { (void)out; return false; }
+    bool popResult(PollardWindow &out) override { (void)out; return false; }
 
     /**
      * Enumerate a key range using the ``windowKernel`` and forward any


### PR DESCRIPTION
## Summary
- allow configuring offset interpretations and enable CRT debug logging in PollardEngine
- support command-line flags for offset basis and CRT debug file
- extend device polling and reconstruction to respect offset basis and emit diagnostics

## Testing
- `make pollard-tests`

------
https://chatgpt.com/codex/tasks/task_e_689574efba58832ea0ad188021d221f3