### PR TITLE
Integrate CUDA kernel updates and offset handling improvements

### DIFF
--- a/CudaKeySearchDevice/CudaPollard.cu
+++ b/CudaKeySearchDevice/CudaPollard.cu
@@ -9,13 +9,6 @@
 
 __device__ void hashPublicKeyCompressed(const uint32_t*, uint32_t, uint32_t*);
 
-#define CUDA_CHECK(call) do { \
-    cudaError_t err = (call); \
-    if(err != cudaSuccess) { \
-        fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__, cudaGetErrorString(err)); \
-    } \
-} while(0)
-
 // Result written by the kernel when a hash window matches a target.
 struct GpuPollardWindow {
     uint32_t targetIdx;

--- a/CudaKeySearchDevice/CudaPollardDevice.cpp
+++ b/CudaKeySearchDevice/CudaPollardDevice.cpp
@@ -1,6 +1,7 @@
 #include "CudaPollardDevice.h"
 #if BUILD_CUDA
 #include <cuda_runtime.h>
+#include "../cudaUtil/cudaUtil.h"
 #endif
 #include <vector>
 #include <cstring>
@@ -9,6 +10,8 @@
 #include <stdexcept>
 #include "windowKernel.h"
 #include <cstdio>
+#include "../Logger/Logger.h"
+#include "../util/util.h"
 
 using namespace secp256k1;
 
@@ -56,7 +59,7 @@ static uint256 hashWindowLE(const uint32_t h[5], uint32_t offset, uint32_t bits)
 // Helper that extracts a window using a big-endian bit offset.  The device
 // kernels expect little-endian offsets so convert prior to slicing.
 static uint256 hashWindowBE(const uint32_t h[5], uint32_t offsetBE, uint32_t bits) {
-    uint32_t offsetLE = 160 - (offsetBE + bits);
+    uint32_t offsetLE = PollardEngine::convertOffset(offsetBE, bits);
     return hashWindowLE(h, offsetLE, bits);
 }
 
@@ -93,8 +96,8 @@ void CudaPollardDevice::startTameWalk(const uint256 &start, uint64_t steps,
     // Determine launch configuration based on device capabilities
     cudaDeviceProp prop;
     int dev = 0;
-    cudaGetDevice(&dev);
-    cudaGetDeviceProperties(&prop, dev);
+    CUDA_CHECK(cudaGetDevice(&dev));
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, dev));
 
     unsigned int threadsPerBlock;
     if(_blockDim) {
@@ -121,6 +124,14 @@ void CudaPollardDevice::startTameWalk(const uint256 &start, uint64_t steps,
 
     unsigned int totalThreads = threadsPerBlock * blocks;
 
+    if(_debug) {
+        Logger::log(LogLevel::Debug,
+                    "CUDA tame walk blocks=" + util::format(blocks) +
+                    " threads=" + util::format(threadsPerBlock) +
+                    " total=" + util::format(totalThreads) +
+                    " steps=" + util::format(steps));
+    }
+
     // Build per-thread 256-bit seeds and starting scalars using the ``start`` value
     std::vector<uint32_t> h_seeds(totalThreads * 8);
     std::vector<uint32_t> h_starts(totalThreads * 8);
@@ -137,12 +148,18 @@ void CudaPollardDevice::startTameWalk(const uint256 &start, uint64_t steps,
     uint32_t *d_seeds = nullptr;
     uint32_t *d_starts = nullptr;
     uint32_t *d_stride = nullptr;
-    cudaMalloc(&d_seeds, sizeof(uint32_t) * totalThreads * 8);
-    cudaMalloc(&d_starts, sizeof(uint32_t) * totalThreads * 8);
-    cudaMalloc(&d_stride, sizeof(uint32_t) * totalThreads * 8);
-    cudaMemcpy(d_seeds, h_seeds.data(), sizeof(uint32_t) * totalThreads * 8, cudaMemcpyHostToDevice);
-    cudaMemcpy(d_starts, h_starts.data(), sizeof(uint32_t) * totalThreads * 8, cudaMemcpyHostToDevice);
-    cudaMemcpy(d_stride, h_stride.data(), sizeof(uint32_t) * totalThreads * 8, cudaMemcpyHostToDevice);
+    CUDA_CHECK(cudaMalloc(&d_seeds, sizeof(uint32_t) * totalThreads * 8));
+    CUDA_CHECK(cudaMalloc(&d_starts, sizeof(uint32_t) * totalThreads * 8));
+    CUDA_CHECK(cudaMalloc(&d_stride, sizeof(uint32_t) * totalThreads * 8));
+    CUDA_CHECK(cudaMemcpy(d_seeds, h_seeds.data(),
+                          sizeof(uint32_t) * totalThreads * 8,
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_starts, h_starts.data(),
+                          sizeof(uint32_t) * totalThreads * 8,
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_stride, h_stride.data(),
+                          sizeof(uint32_t) * totalThreads * 8,
+                          cudaMemcpyHostToDevice));
 
     // Prepare target windows. Offsets supplied via the CLI are measured from the
     // most-significant bit of the hash (big-endian).  Convert them to the
@@ -154,7 +171,7 @@ void CudaPollardDevice::startTameWalk(const uint256 &start, uint64_t steps,
             if(offBE + _windowBits > 160) {
                 continue;
             }
-            unsigned int offLE = 160 - (offBE + _windowBits);
+            unsigned int offLE = PollardEngine::convertOffset(offBE, _windowBits);
             GpuTargetWindow tw;
             tw.targetIdx = static_cast<uint32_t>(t);
             tw.offset    = offLE;
@@ -167,19 +184,21 @@ void CudaPollardDevice::startTameWalk(const uint256 &start, uint64_t steps,
     uint32_t windowCount = static_cast<uint32_t>(h_windows.size());
     GpuTargetWindow *d_windows = nullptr;
     if(windowCount > 0) {
-        cudaMalloc(&d_windows, sizeof(GpuTargetWindow) * windowCount);
-        cudaMemcpy(d_windows, h_windows.data(), sizeof(GpuTargetWindow) * windowCount, cudaMemcpyHostToDevice);
+        CUDA_CHECK(cudaMalloc(&d_windows, sizeof(GpuTargetWindow) * windowCount));
+        CUDA_CHECK(cudaMemcpy(d_windows, h_windows.data(),
+                              sizeof(GpuTargetWindow) * windowCount,
+                              cudaMemcpyHostToDevice));
     }
 
     GpuPollardWindow *d_out = nullptr;
     uint32_t *d_count = nullptr;
     uint32_t maxOut = std::min<uint32_t>(1024, static_cast<uint32_t>(steps * totalThreads));
-    cudaMalloc(&d_out, sizeof(GpuPollardWindow) * maxOut);
-    cudaMalloc(&d_count, sizeof(uint32_t));
-    cudaMemset(d_count, 0, sizeof(uint32_t));
+    CUDA_CHECK(cudaMalloc(&d_out, sizeof(GpuPollardWindow) * maxOut));
+    CUDA_CHECK(cudaMalloc(&d_count, sizeof(uint32_t)));
+    CUDA_CHECK(cudaMemset(d_count, 0, sizeof(uint32_t)));
 
     cudaStream_t stream;
-    cudaStreamCreate(&stream);
+    CUDA_CHECK(cudaStreamCreate(&stream));
 #if BUILD_CUDA
     pollardWalk<<<blocks, threadsPerBlock, 0, stream>>>(d_out, d_count, maxOut,
                                                        d_seeds, d_starts,
@@ -191,14 +210,17 @@ void CudaPollardDevice::startTameWalk(const uint256 &start, uint64_t steps,
 
     std::vector<GpuPollardWindow> h_out(maxOut);
     uint32_t h_count = 0;
-    cudaMemcpyAsync(&h_count, d_count, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream);
-    cudaMemcpyAsync(h_out.data(), d_out, sizeof(GpuPollardWindow) * maxOut, cudaMemcpyDeviceToHost, stream);
-    cudaStreamSynchronize(stream);
+    CUDA_CHECK(cudaMemcpyAsync(&h_count, d_count, sizeof(uint32_t),
+                               cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_out.data(), d_out,
+                               sizeof(GpuPollardWindow) * maxOut,
+                               cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     uint32_t count = (h_count > maxOut) ? maxOut : h_count;
     for(uint32_t i = 0; i < count; ++i) {
         unsigned int offsetLE = h_out[i].offset;
-        unsigned int modBits  = 160u - offsetLE;
+        unsigned int modBits  = offsetLE + _windowBits;
         secp256k1::uint256 rem;
         for(int j = 0; j < 8; ++j) {
             rem.v[j] = h_out[i].k[j];
@@ -226,13 +248,13 @@ void CudaPollardDevice::startTameWalk(const uint256 &start, uint64_t steps,
         _engine.processWindow(h_out[i].targetIdx, offsetLE, c);
     }
 
-    cudaFree(d_out);
-    cudaFree(d_count);
-    cudaFree(d_seeds);
-    cudaFree(d_starts);
-    cudaFree(d_stride);
-    if(d_windows) cudaFree(d_windows);
-    cudaStreamDestroy(stream);
+    CUDA_CHECK(cudaFree(d_out));
+    CUDA_CHECK(cudaFree(d_count));
+    CUDA_CHECK(cudaFree(d_seeds));
+    CUDA_CHECK(cudaFree(d_starts));
+    CUDA_CHECK(cudaFree(d_stride));
+    if(d_windows) CUDA_CHECK(cudaFree(d_windows));
+    CUDA_CHECK(cudaStreamDestroy(stream));
 }
 
 void CudaPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
@@ -240,8 +262,8 @@ void CudaPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
     // Determine launch configuration similar to tame walk
     cudaDeviceProp prop;
     int dev = 0;
-    cudaGetDevice(&dev);
-    cudaGetDeviceProperties(&prop, dev);
+    CUDA_CHECK(cudaGetDevice(&dev));
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, dev));
 
     unsigned int threadsPerBlock;
     if(_blockDim) {
@@ -267,6 +289,14 @@ void CudaPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
     }
 
     unsigned int totalThreads = threadsPerBlock * blocks;
+
+    if(_debug) {
+        Logger::log(LogLevel::Debug,
+                    "CUDA wild walk blocks=" + util::format(blocks) +
+                    " threads=" + util::format(threadsPerBlock) +
+                    " total=" + util::format(totalThreads) +
+                    " steps=" + util::format(steps));
+    }
 
     // Prepare per-thread 256-bit seeds, starting scalars and points
     std::vector<uint32_t> h_seeds(totalThreads * 8);
@@ -308,16 +338,26 @@ void CudaPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
     uint32_t *d_startX = nullptr;
     uint32_t *d_startY = nullptr;
     uint32_t *d_stride = nullptr;
-    cudaMalloc(&d_seeds, sizeof(uint32_t) * totalThreads * 8);
-    cudaMalloc(&d_starts, sizeof(uint32_t) * totalThreads * 8);
-    cudaMalloc(&d_startX, sizeof(uint32_t) * totalThreads * 8);
-    cudaMalloc(&d_startY, sizeof(uint32_t) * totalThreads * 8);
-    cudaMalloc(&d_stride, sizeof(uint32_t) * totalThreads * 8);
-    cudaMemcpy(d_seeds, h_seeds.data(), sizeof(uint32_t) * totalThreads * 8, cudaMemcpyHostToDevice);
-    cudaMemcpy(d_starts, h_starts.data(), sizeof(uint32_t) * totalThreads * 8, cudaMemcpyHostToDevice);
-    cudaMemcpy(d_startX, h_startX.data(), sizeof(uint32_t) * totalThreads * 8, cudaMemcpyHostToDevice);
-    cudaMemcpy(d_startY, h_startY.data(), sizeof(uint32_t) * totalThreads * 8, cudaMemcpyHostToDevice);
-    cudaMemcpy(d_stride, h_stride.data(), sizeof(uint32_t) * totalThreads * 8, cudaMemcpyHostToDevice);
+    CUDA_CHECK(cudaMalloc(&d_seeds, sizeof(uint32_t) * totalThreads * 8));
+    CUDA_CHECK(cudaMalloc(&d_starts, sizeof(uint32_t) * totalThreads * 8));
+    CUDA_CHECK(cudaMalloc(&d_startX, sizeof(uint32_t) * totalThreads * 8));
+    CUDA_CHECK(cudaMalloc(&d_startY, sizeof(uint32_t) * totalThreads * 8));
+    CUDA_CHECK(cudaMalloc(&d_stride, sizeof(uint32_t) * totalThreads * 8));
+    CUDA_CHECK(cudaMemcpy(d_seeds, h_seeds.data(),
+                          sizeof(uint32_t) * totalThreads * 8,
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_starts, h_starts.data(),
+                          sizeof(uint32_t) * totalThreads * 8,
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_startX, h_startX.data(),
+                          sizeof(uint32_t) * totalThreads * 8,
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_startY, h_startY.data(),
+                          sizeof(uint32_t) * totalThreads * 8,
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_stride, h_stride.data(),
+                          sizeof(uint32_t) * totalThreads * 8,
+                          cudaMemcpyHostToDevice));
 
     // Prepare target windows using little-endian offsets for the device
     std::vector<GpuTargetWindow> h_windows;
@@ -326,7 +366,7 @@ void CudaPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
             if(offBE + _windowBits > 160) {
                 continue;
             }
-            unsigned int offLE = 160 - (offBE + _windowBits);
+            unsigned int offLE = PollardEngine::convertOffset(offBE, _windowBits);
             GpuTargetWindow tw;
             tw.targetIdx = static_cast<uint32_t>(t);
             tw.offset    = offLE;
@@ -339,19 +379,21 @@ void CudaPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
     uint32_t windowCount = static_cast<uint32_t>(h_windows.size());
     GpuTargetWindow *d_windows = nullptr;
     if(windowCount > 0) {
-        cudaMalloc(&d_windows, sizeof(GpuTargetWindow) * windowCount);
-        cudaMemcpy(d_windows, h_windows.data(), sizeof(GpuTargetWindow) * windowCount, cudaMemcpyHostToDevice);
+        CUDA_CHECK(cudaMalloc(&d_windows, sizeof(GpuTargetWindow) * windowCount));
+        CUDA_CHECK(cudaMemcpy(d_windows, h_windows.data(),
+                              sizeof(GpuTargetWindow) * windowCount,
+                              cudaMemcpyHostToDevice));
     }
 
     GpuPollardWindow *d_out = nullptr;
     uint32_t *d_count = nullptr;
     uint32_t maxOut = std::min<uint32_t>(1024, static_cast<uint32_t>(steps * totalThreads));
-    cudaMalloc(&d_out, sizeof(GpuPollardWindow) * maxOut);
-    cudaMalloc(&d_count, sizeof(uint32_t));
-    cudaMemset(d_count, 0, sizeof(uint32_t));
+    CUDA_CHECK(cudaMalloc(&d_out, sizeof(GpuPollardWindow) * maxOut));
+    CUDA_CHECK(cudaMalloc(&d_count, sizeof(uint32_t)));
+    CUDA_CHECK(cudaMemset(d_count, 0, sizeof(uint32_t)));
 
     cudaStream_t stream;
-    cudaStreamCreate(&stream);
+    CUDA_CHECK(cudaStreamCreate(&stream));
 #if BUILD_CUDA
     pollardWalk<<<blocks, threadsPerBlock, 0, stream>>>(d_out, d_count, maxOut,
                                                        d_seeds, d_starts,
@@ -363,14 +405,17 @@ void CudaPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
 
     std::vector<GpuPollardWindow> h_out(maxOut);
     uint32_t h_count = 0;
-    cudaMemcpyAsync(&h_count, d_count, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream);
-    cudaMemcpyAsync(h_out.data(), d_out, sizeof(GpuPollardWindow) * maxOut, cudaMemcpyDeviceToHost, stream);
-    cudaStreamSynchronize(stream);
+    CUDA_CHECK(cudaMemcpyAsync(&h_count, d_count, sizeof(uint32_t),
+                               cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_out.data(), d_out,
+                               sizeof(GpuPollardWindow) * maxOut,
+                               cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     uint32_t count = (h_count > maxOut) ? maxOut : h_count;
     for(uint32_t i = 0; i < count; ++i) {
         unsigned int offsetLE = h_out[i].offset;
-        unsigned int modBits  = 160u - offsetLE;
+        unsigned int modBits  = offsetLE + _windowBits;
         secp256k1::uint256 rem;
         for(int j = 0; j < 8; ++j) {
             rem.v[j] = h_out[i].k[j];
@@ -398,15 +443,15 @@ void CudaPollardDevice::startWildWalk(const uint256 &start, uint64_t steps,
         _engine.processWindow(h_out[i].targetIdx, offsetLE, c);
     }
 
-    cudaFree(d_out);
-    cudaFree(d_count);
-    cudaFree(d_seeds);
-    cudaFree(d_starts);
-    cudaFree(d_startX);
-    cudaFree(d_startY);
-    cudaFree(d_stride);
-    if(d_windows) cudaFree(d_windows);
-    cudaStreamDestroy(stream);
+    CUDA_CHECK(cudaFree(d_out));
+    CUDA_CHECK(cudaFree(d_count));
+    CUDA_CHECK(cudaFree(d_seeds));
+    CUDA_CHECK(cudaFree(d_starts));
+    CUDA_CHECK(cudaFree(d_startX));
+    CUDA_CHECK(cudaFree(d_startY));
+    CUDA_CHECK(cudaFree(d_stride));
+    if(d_windows) CUDA_CHECK(cudaFree(d_windows));
+    CUDA_CHECK(cudaStreamDestroy(stream));
 }
 
 void CudaPollardDevice::scanKeyRange(uint64_t start_k,
@@ -422,7 +467,7 @@ void CudaPollardDevice::scanKeyRange(uint64_t start_k,
         if(offBE + windowBits > 160) {
             continue;
         }
-        offsetsLE.push_back(160 - (offBE + windowBits));
+        offsetsLE.push_back(PollardEngine::convertOffset(offBE, windowBits));
     }
     uint32_t offsetsCount = static_cast<uint32_t>(offsetsLE.size());
     if(offsetsCount == 0 || windowBits == 0) {
@@ -435,55 +480,58 @@ void CudaPollardDevice::scanKeyRange(uint64_t start_k,
     MatchRecord *d_out = nullptr;
     uint32_t *d_count = nullptr;
 
-    cudaMalloc(&d_offsets, offsetsCount * sizeof(uint32_t));
-    cudaError_t err = cudaGetLastError();
-    if(err != cudaSuccess) { fprintf(stderr, "CUDA error: %s\n", cudaGetErrorString(err)); exit(1); }
-    cudaMalloc(&d_targets, offsetsCount * sizeof(uint32_t));
-    err = cudaGetLastError();
-    if(err != cudaSuccess) { fprintf(stderr, "CUDA error: %s\n", cudaGetErrorString(err)); exit(1); }
-    cudaMalloc(&d_out, sizeof(MatchRecord) * 1024);
-    err = cudaGetLastError();
-    if(err != cudaSuccess) { fprintf(stderr, "CUDA error: %s\n", cudaGetErrorString(err)); exit(1); }
-    cudaMalloc(&d_count, sizeof(uint32_t));
-    err = cudaGetLastError();
-    if(err != cudaSuccess) { fprintf(stderr, "CUDA error: %s\n", cudaGetErrorString(err)); exit(1); }
+    CUDA_CHECK(cudaMalloc(&d_offsets, offsetsCount * sizeof(uint32_t)));
+    CUDA_CHECK(cudaMalloc(&d_targets, offsetsCount * sizeof(uint32_t)));
+    CUDA_CHECK(cudaMalloc(&d_out, sizeof(MatchRecord) * 1024));
+    CUDA_CHECK(cudaMalloc(&d_count, sizeof(uint32_t)));
 
-    cudaMemcpy(d_offsets, offsetsLE.data(), offsetsCount * sizeof(uint32_t), cudaMemcpyHostToDevice);
-    err = cudaGetLastError();
-    if(err != cudaSuccess) { fprintf(stderr, "CUDA error: %s\n", cudaGetErrorString(err)); exit(1); }
-    cudaMemcpy(d_targets, targetFragments, offsetsCount * sizeof(uint32_t), cudaMemcpyHostToDevice);
-    err = cudaGetLastError();
-    if(err != cudaSuccess) { fprintf(stderr, "CUDA error: %s\n", cudaGetErrorString(err)); exit(1); }
+    cudaStream_t stream;
+    CUDA_CHECK(cudaStreamCreate(&stream));
+
+    CUDA_CHECK(cudaMemcpyAsync(d_offsets, offsetsLE.data(),
+                              offsetsCount * sizeof(uint32_t),
+                              cudaMemcpyHostToDevice, stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_targets, targetFragments,
+                              offsetsCount * sizeof(uint32_t),
+                              cudaMemcpyHostToDevice, stream));
 
     std::vector<MatchRecord> hostOut(1024);
     std::unordered_set<uint32_t> seen;
 
     cudaDeviceProp prop;
     int dev = 0;
-    cudaGetDevice(&dev);
-    cudaGetDeviceProperties(&prop, dev);
+    CUDA_CHECK(cudaGetDevice(&dev));
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, dev));
 
     uint64_t chunk = (1ULL << 32);
     for(uint64_t chunkStart = start_k; chunkStart < end_k && seen.size() < offsetsCount; chunkStart += chunk) {
         uint64_t range = std::min(chunk, end_k - chunkStart);
 
-        cudaMemset(d_count, 0, sizeof(uint32_t));
-        err = cudaGetLastError();
-        if(err != cudaSuccess) { fprintf(stderr, "CUDA error: %s\n", cudaGetErrorString(err)); exit(1); }
 #if BUILD_CUDA
-        launchWindowKernel(chunkStart, range, windowBits,
-                           d_offsets, offsetsCount, mask, d_targets,
-                           d_out, d_count);
+        launchWindowKernel(dim3(), dim3(),
+                           chunkStart, range, windowBits,
+                           d_offsets, offsetsCount,
+                           d_targets, d_out,
+                           d_count,
+                           static_cast<unsigned int>(hostOut.size()),
+                           stream);
 #endif
 
         uint32_t hCount = 0;
-        cudaMemcpy(&hCount, d_count, sizeof(uint32_t), cudaMemcpyDeviceToHost);
-        err = cudaGetLastError();
-        if(err != cudaSuccess) { fprintf(stderr, "CUDA error: %s\n", cudaGetErrorString(err)); exit(1); }
+        CUDA_CHECK(cudaMemcpyAsync(&hCount, d_count, sizeof(uint32_t),
+                                  cudaMemcpyDeviceToHost, stream));
+        CUDA_CHECK(cudaMemcpyAsync(hostOut.data(), d_out,
+                                  hostOut.size() * sizeof(MatchRecord),
+                                  cudaMemcpyDeviceToHost, stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
         if(hCount > hostOut.size()) hCount = hostOut.size();
-        cudaMemcpy(hostOut.data(), d_out, hCount * sizeof(MatchRecord), cudaMemcpyDeviceToHost);
-        err = cudaGetLastError();
-        if(err != cudaSuccess) { fprintf(stderr, "CUDA error: %s\n", cudaGetErrorString(err)); exit(1); }
+
+        if(_debug) {
+            Logger::log(LogLevel::Debug,
+                        "Processed " + util::format(range) +
+                            " windows, matches " +
+                            util::format(hCount));
+        }
 
         for(uint32_t i = 0; i < hCount; ++i) {
             const MatchRecord &r = hostOut[i];
@@ -514,10 +562,11 @@ void CudaPollardDevice::scanKeyRange(uint64_t start_k,
         }
     }
 
-    cudaFree(d_offsets);
-    cudaFree(d_targets);
-    cudaFree(d_out);
-    cudaFree(d_count);
+    CUDA_CHECK(cudaStreamDestroy(stream));
+    CUDA_CHECK(cudaFree(d_offsets));
+    CUDA_CHECK(cudaFree(d_targets));
+    CUDA_CHECK(cudaFree(d_out));
+    CUDA_CHECK(cudaFree(d_count));
 }
 
 extern "C" bool runCudaHashWindow(const unsigned int h[5], unsigned int offset,

--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -5,6 +5,8 @@ MATHSRC:=$(CUDA_MATH)/sha256_constants.cu $(CUDA_MATH)/ripemd160_constants.cu
 
 CPPOBJS:=$(addsuffix .o,$(CPPSRC))
 CUOBJS:=$(addsuffix .o,$(basename $(CUSRC)))
+# Ensure device code sees BUILD_CUDA definition
+NVCCFLAGS+=-DBUILD_CUDA=1
 # ``windowKernel.o`` is linked separately by the KeyFinder binary to expose the
 # kernel entry point; exclude it from the static archive to avoid duplicate
 # definitions when linking the final executable.

--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -3,14 +3,14 @@ CPPSRC=ConfigFile.cpp DeviceManager.cpp PollardEngine.cpp main.cpp
 all:
 ifeq ($(BUILD_CUDA), 1)
 	${NVCC} -DBUILD_CUDA -std=c++11 -rdc=true -o cuKeyFinder.bin ${CPPSRC} ../CudaKeySearchDevice/windowKernel.o \
-	${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} -L${LIBDIR} -L../CudaKeySearchDevice \
-	-lCudaKeySearchDevice -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lcudautil -llogger -lutil \
-	-lcudart -lcmdparse
+${INCLUDE} -I${CUDA_INCLUDE} ${NVCCFLAGS} ${LIBS} -L${CUDA_LIB} -L${LIBDIR} -L../CudaKeySearchDevice \
+-lCudaKeySearchDevice -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lcudautil -llogger -lutil \
+-lcudart -lcmdparse
 		mkdir -p $(BINDIR)
 		cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
 endif
 ifeq ($(BUILD_OPENCL),1)
-		${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
+${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
 		mkdir -p $(BINDIR)
 		cp clKeyFinder.bin $(BINDIR)/clBitCrack
 endif

--- a/PollardTests/cuda_scalar_one.cu
+++ b/PollardTests/cuda_scalar_one.cu
@@ -17,7 +17,7 @@ __device__ static void doRMD160FinalRound(const unsigned int hIn[5], unsigned in
     }
 }
 
-__device__ void hashPublicKeyCompressed(const unsigned int *x, unsigned int yParity, unsigned int *digestOut)
+__device__ static void hashPublicKeyCompressed(const unsigned int *x, unsigned int yParity, unsigned int *digestOut)
 {
     unsigned int hash[8];
     sha256PublicKeyCompressed(x, yParity, hash);

--- a/cudaUtil/cudaUtil.h
+++ b/cudaUtil/cudaUtil.h
@@ -4,8 +4,22 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+#include <cstdio>
+#include <cstdlib>
 #include <string>
 #include <vector>
+
+#define CUDA_CHECK(call)                                                         \
+    do {                                                                         \
+        cudaError_t err__ = (call);                                              \
+        if (err__ != cudaSuccess) {                                              \
+            fprintf(stderr,                                                     \
+                    "CUDA error at %s:%d (%s): %s\n",                            \
+                    __FILE__, __LINE__, #call,                                   \
+                    cudaGetErrorString(err__));                                  \
+            exit(1);                                                             \
+        }                                                                        \
+    } while (0)
 
 namespace cuda {
 	typedef struct {

--- a/secp256k1lib/secp256k1.cpp
+++ b/secp256k1lib/secp256k1.cpp
@@ -613,7 +613,7 @@ uint256 secp256k1::multiplyModN(const uint256 &a, const uint256 &b)
 	return r;
 }
 
-std::string secp256k1::uint256::toString(int base)
+std::string secp256k1::uint256::toString(int base) const
 {
 	std::string s = "";
 

--- a/secp256k1lib/secp256k1.h
+++ b/secp256k1lib/secp256k1.h
@@ -264,19 +264,20 @@ namespace secp256k1 {
 			return product;
 		}
 
-		bool bit(int n)
-		{
-			n = n % 256;
+                bool bit(int n) const
+                {
+                        n = n % 256;
 
-			return (this->v[n / 32] & (0x1 << (n % 32))) != 0;
-		}
+                        return (this->v[n / 32] & (0x1 << (n % 32))) != 0;
+                }
 
-		bool isEven()
-		{
-			return (this->v[0] & 1) == 0;
-		}
+                bool isEven() const
+                {
+                        return (this->v[0] & 1) == 0;
+                }
 
-		std::string toString(int base = 16);
+
+               std::string toString(int base = 16) const;
 
         uint64_t toUint64()
         {


### PR DESCRIPTION
## Summary
- add lightweight dim3 definition and updated launchWindowKernel interface for simpler GPU builds
- convert hash offset handling to little-endian and adjust PollardEngine to call new kernel
- streamline build scripts for CUDA/Pollard tests

## Testing
- `timeout 60 make pollard-tests BUILD_CUDA=0 BUILD_OPENCL=0` *(fails: undefined reference to CUDA/OpenCL symbols)*

------
https://chatgpt.com/codex/tasks/task_e_689594cefb04832e97ecdacd440751d2